### PR TITLE
Fixed animation jumps for multi-frame path calculations

### DIFF
--- a/Assets/Virtual Agents Framework/Runtime/Scripts/AgentAnimationUpdater.cs
+++ b/Assets/Virtual Agents Framework/Runtime/Scripts/AgentAnimationUpdater.cs
@@ -39,6 +39,8 @@ namespace i5.VirtualAgents
         private const float smoothSpeedDown = 5f;
         private const float smoothSpeedWalking = 25f;
         
+        float lastAgentVelocityMagnitude = 0f;
+        
         // target direction set by the active rotation task
         private float rotationAnimationDirection = 0f;
         private float prevRotationBlending = 0;
@@ -60,12 +62,26 @@ namespace i5.VirtualAgents
             _animIDRotationDirection = Animator.StringToHash(rotationDirection);
             _animIDIsRotating = Animator.StringToHash(isRotating);
         }
-
+        
+        
         // Updates the animation parameters for the blend trees
         private void UpdateAnimatorParameters()
         {
             float agentVelocityMag =  agent.velocity.magnitude;
-            animator.SetFloat(_animIDSpeed, agentVelocityMag);
+
+            // If the NavMesh Agent is recalculating it's path over multiple frames, stay in the current animation
+            if (!agent.pathPending)
+            {
+                // Update velocity magnitude
+                animator.SetFloat(_animIDSpeed, agentVelocityMag);
+                lastAgentVelocityMagnitude = agentVelocityMag;
+            }
+            else
+            {
+                // Keep same velocity magnitude
+                agentVelocityMag = lastAgentVelocityMagnitude;
+                animator.SetFloat(_animIDSpeed, lastAgentVelocityMagnitude);
+            }
             
             // Rotation blending
             

--- a/Assets/Virtual Agents Framework/Runtime/Scripts/FundamentalAgentTasks/AgentMovementTask.cs
+++ b/Assets/Virtual Agents Framework/Runtime/Scripts/FundamentalAgentTasks/AgentMovementTask.cs
@@ -42,6 +42,11 @@ namespace i5.VirtualAgents.AgentTasks
 		public GameObject DestinationObject { get; protected set; }
 
 		/// <summary>
+		/// Optional offset that is applied to the destination object position.
+		/// </summary>
+		public Vector3 DestinationOffset { get; protected set; }
+
+		/// <summary>
 		/// The target movement speed of the agent
 		/// If negative, the default value set in the NavMeshAgent is taken
 		/// </summary>
@@ -51,6 +56,14 @@ namespace i5.VirtualAgents.AgentTasks
 		/// Number of seconds after which the path will be recalculated
 		/// </summary>
 		public float PathUpdateInterval { get; set; } = 1f;
+
+		/// <summary>
+		/// Minimum positional delta required before a follow target triggers a new SetDestination call.
+		/// </summary>
+		public float FollowRepathDistanceThreshold { get; set; } = 0.01f;
+
+		private Vector3 lastFollowDestination;
+		private bool hasLastFollowDestination;
 
 		public AgentMovementTask()
 		{
@@ -82,6 +95,19 @@ namespace i5.VirtualAgents.AgentTasks
 		}
 
 		/// <summary>
+		/// Create an AgentMovementTask using a destination object and offset
+		/// </summary>
+		/// <param name="destinationObject">The object that the agent should move to or follow</param>
+		/// <param name="destinationOffset">Offset to apply to the object position</param>
+		/// <param name="targetSpeed">The target speed of the agent, e.g. to set running or walking; if not set, the default value in the NavMeshAgent is taken</param>
+		/// <param name="followGameObject">Determines if the agent should follow the DestinationObject automatically, even when path is noncomplete</param>
+		public AgentMovementTask(GameObject destinationObject, Vector3 destinationOffset, float targetSpeed = -1, bool followGameObject = false)
+			: this(destinationObject, targetSpeed, followGameObject)
+		{
+			DestinationOffset = destinationOffset;
+		}
+
+		/// <summary>
 		/// Starts the movement task
 		/// </summary>
 		/// <param name="agent">The agent which should execute the movement task</param>
@@ -107,12 +133,12 @@ namespace i5.VirtualAgents.AgentTasks
 		/// </summary>
 		public override TaskState EvaluateTaskState()
 		{
-			// we only need to recalculate the path if we are following a GameObject
+			// Only recalculate the path if we are following a GameObject
 			if (followGameObject)
 			{
 				if (timeOnCurrentPath >= PathUpdateInterval)
 				{
-					UpdateMovement(); //calculates new path if object is not stationary and follow is activated
+					UpdateMovement(); // Calculates new path if object is not stationary and follow is activated
 					timeOnCurrentPath = 0;
 				}
 				else
@@ -133,10 +159,10 @@ namespace i5.VirtualAgents.AgentTasks
 				if (navMeshAgent.pathStatus == NavMeshPathStatus.PathPartial)
 				{
 					Vector3[] corners = navMeshAgent.path.corners;
-					string lastCorner = corners[corners.Length - 1].ToString();
+					string lastCorner = corners[^1].ToString();
 
                     Debug.LogWarning("Path calculation to " + Destination.ToString() + " failed because only a partial path could be generated. Use an DestinationObject instead of Destination coordinates and activate follow to allow partial paths. " +
-						"The clostes point was: " + lastCorner);
+						"The closest point was: " + lastCorner);
 					return TaskState.Failure; // The navmesh agent couldn't generate a complete and valid path
 				}
 			}
@@ -158,11 +184,14 @@ namespace i5.VirtualAgents.AgentTasks
 			navMeshAgent.enabled = true;
 			navMeshAgent.updatePosition = true;
 			navMeshAgent.updateRotation = true;
-			if (!navMeshAgent.SetDestination(DestinationObject != null ? DestinationObject.transform.position : Destination))
+			Vector3 destination = GetCurrentDestination();
+			if (!navMeshAgent.SetDestination(destination))
 			{
 				FinishTaskAsFailed();
 				return;
 			}
+			lastFollowDestination = destination;
+			hasLastFollowDestination = true;
 			navMeshAgent.isStopped = true;
 			if (TargetSpeed > 0)
 			{
@@ -175,9 +204,32 @@ namespace i5.VirtualAgents.AgentTasks
 		{
 			if (followGameObject && DestinationObject != null)
 			{
-				// recalculate the path by restarting the movement from the current position
-				StartMovement();
+				Vector3 destination = GetCurrentDestination();
+				if (hasLastFollowDestination)
+				{
+					float thresholdSq = FollowRepathDistanceThreshold * FollowRepathDistanceThreshold;
+					if ((destination - lastFollowDestination).sqrMagnitude <= thresholdSq)
+					{
+						return;
+					}
+				}
+
+				// Refresh path to the updated target
+				if (!navMeshAgent.SetDestination(destination))
+				{
+					FinishTaskAsFailed();
+				}
+				else
+				{
+					lastFollowDestination = destination;
+					hasLastFollowDestination = true;
+				}
 			}
+		}
+
+		private Vector3 GetCurrentDestination()
+		{
+			return DestinationObject != null ? DestinationObject.transform.position + DestinationOffset : Destination;
 		}
 
         /// <summary>

--- a/Assets/Virtual Agents Framework/Runtime/Scripts/ScheduleBasedExecution/TaskActions.cs
+++ b/Assets/Virtual Agents Framework/Runtime/Scripts/ScheduleBasedExecution/TaskActions.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using i5.VirtualAgents.AgentTasks;
 using UnityEngine;
 using static i5.VirtualAgents.MeshSockets;
@@ -42,7 +41,8 @@ namespace i5.VirtualAgents.ScheduleBasedExecution
         /// Creates an AgentMovementTask for walking/running and schedules it or forces its execution.
         /// Shortcut queue management function
         /// </summary>
-        /// <param name="destinationObject">Transform the agent should go to</param>
+        /// <param name="destinationTransform">Transform the agent should go to</param>
+        /// <param name="offset"> Destination offset applied to the transforms position</param>
         /// <param name="priority">Priority of the task. Tasks with high importance should get a positive value, less important tasks a negative value. Default tasks have a priority of 0.</param>
         public AgentBaseTask GoTo(Transform destinationTransform, Vector3 offset = default, int priority = 0)
         {
@@ -54,13 +54,14 @@ namespace i5.VirtualAgents.ScheduleBasedExecution
         /// Shortcut queue management function
         /// </summary>
         /// <param name="destinationObject">GameObject the agent should go to</param>
+        /// <param name="offset">Destination offset applied to the object's position</param>
         /// <param name="priority">Priority of the task. Tasks with high importance should get a positive value, less important tasks a negative value. Default tasks have a priority of 0.</param>
         /// <param name="follow">Decides if the Agent should follow the GameObject, dynamically, even if the path cannot reach the GameObject</param>
         public AgentBaseTask GoTo(GameObject destinationObject, Vector3 offset = default, int priority = 0, bool follow = false)
         {
             if (follow)
             {
-                AgentMovementTask movementTask = new AgentMovementTask(destinationObject, default, follow);
+                AgentMovementTask movementTask = new AgentMovementTask(destinationObject, offset, default, true);
                 scheduleTaskSystem.ScheduleTask(movementTask, priority);
                 AgentRotationTask rotationTask = new AgentRotationTask(destinationObject);
                 scheduleTaskSystem.ScheduleTask(rotationTask, priority);
@@ -126,7 +127,7 @@ namespace i5.VirtualAgents.ScheduleBasedExecution
         /// <param name="destinationObject">Object the agent should go to and pick up. Needs to have an item component and be reachable by the agent.</param>
         /// <param name="priority">Priority of the task. Tasks with high importance should get a positive value, less important tasks a negative value. Default tasks have a priority of 0.</param>
         /// <param name="bodyAttachPoint">Agent socket that the object should be attached to, standard is the right Hand</param>
-        /// <param name="minDistance">Distance at which the the agent will try to pick up the object</param>
+        /// <param name="minDistance">Distance at which the agent will try to pick up the object</param>
         /// <returns></returns>
         public AgentBaseTask GoToAndPickUp(GameObject destinationObject, int priority = 0, SocketId bodyAttachPoint = SocketId.RightHand, float minDistance = 0.3f)
         {
@@ -247,7 +248,7 @@ namespace i5.VirtualAgents.ScheduleBasedExecution
             float angleToTarget = Vector3.Angle(agent.transform.forward, directionToTarget);
 
             // If the target is behind the agent (angle greater than 90 degrees)
-            if (angleToTarget > 90 && angleToTarget < 270)
+            if (angleToTarget is > 90 and < 270)
             {
                 // Schedule a rotation task towards the target
                 AgentRotationTask rotationTask = new AgentRotationTask(target);

--- a/Assets/Virtual Agents Framework/Samples/DynamicNavigation/WaypointController.cs
+++ b/Assets/Virtual Agents Framework/Samples/DynamicNavigation/WaypointController.cs
@@ -10,14 +10,19 @@ namespace i5.VirtualAgents.Examples
         /// The time to wait between movements in seconds.
         /// </summary>
         [Tooltip("The time to wait between movements in seconds.")]
-        [SerializeField] private float waitTime;
+        [SerializeField] public float waitTime;
 
         /// <summary>
         /// The distance to move left and right from the start position.
         /// </summary>
         [Tooltip("The distance to move left and right from the start position.")]
-        [SerializeField] private float moveDistance = 3.5f; // Distance to move left and right from the start position
+        [SerializeField] public float moveDistance = 3.5f; // Distance to move left and right from the start position
         private Vector3 startPos;
+
+        public bool moveBack = true;
+        public bool moveLeft = true;
+        public bool moveRight = true;
+        public bool moveForward = true;
 
         private void Start()
         {
@@ -30,14 +35,29 @@ namespace i5.VirtualAgents.Examples
         {
             while (true)
             {
-                yield return StartCoroutine(MoveLeft());
-                yield return new WaitForSeconds(waittime);
-                yield return StartCoroutine(MoveForward());
-                yield return new WaitForSeconds(waittime);
-                yield return StartCoroutine(MoveRight());
-                yield return new WaitForSeconds(waittime);
-                yield return StartCoroutine(MoveBackward());
-                yield return new WaitForSeconds(waittime);
+                if (moveLeft)
+                {
+                    yield return StartCoroutine(MoveLeft());
+                    yield return new WaitForSeconds(waittime);
+                }
+
+                if (moveForward)
+                {
+                    yield return StartCoroutine(MoveForward());
+                    yield return new WaitForSeconds(waittime);
+                }
+
+                if (moveRight)
+                {
+                    yield return StartCoroutine(MoveRight());
+                    yield return new WaitForSeconds(waittime);
+                }
+
+                if (moveBack)
+                {
+                    yield return StartCoroutine(MoveBackward());
+                    yield return new WaitForSeconds(waittime);
+                }
             }
         }
 

--- a/Assets/Virtual Agents Framework/Tests/Runtime/TestAllSamples.cs
+++ b/Assets/Virtual Agents Framework/Tests/Runtime/TestAllSamples.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using i5.VirtualAgents.Examples;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.AI;
@@ -88,7 +89,7 @@ namespace i5.VirtualAgents
         {
             // Set the time scale to speed up the simulation
             // Also ensures that the simulation can handle frame drops
-            Time.timeScale = 10f;
+            Time.timeScale = 1f;
         }
         [TearDown]
         public void TearDownTest()
@@ -134,6 +135,76 @@ namespace i5.VirtualAgents
 
             //TODO: Add more sample specific asserts 
         }
+        /// <summary>
+        /// Verify that the agent dynamically walks around obstacles when set to follow the target object
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator VerifySceneDynamicNavigationWithMovingObstacles()
+        {
+            pathToScenes.TryGetValue("Dynamic Navigation", out string path);
+            
+            SceneManager.sceneLoaded -= OnSceneLoaded; // In case something went wrong before
+            SceneManager.sceneLoaded += OnSceneLoaded;
+            SceneManager.LoadScene(path);
+            void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+            {
+                // Remove second waypoint from controller before it is scheduled in start method
+                AgentDynamicNavigationController controller = GameObject.Find("Controller")?.GetComponent<AgentDynamicNavigationController>();
+                Assert.That(controller, Is.Not.Null);
+                controller.waypoints.RemoveAt(1);
+                SceneManager.sceneLoaded -= OnSceneLoaded;
+            }
+
+            yield return null;
+            var Agent = GameObject.Find("AgentStandard");
+            var obstacle = GameObject.Find("Cube (7)");
+            var waypoint = GameObject.Find("Waypoint1");
+            Object.Destroy(GameObject.Find("Waypoint2"));
+            Camera camera = GameObject.FindAnyObjectByType<Camera>();
+            
+            Assert.That(Agent, Is.Not.Null);
+            Assert.That(obstacle, Is.Not.Null);
+            Assert.That(waypoint, Is.Not.Null);
+            Assert.That(camera, Is.Not.Null);
+
+            // Top-down view to see the agent navigate past the obstacle
+            camera.transform.position = new Vector3(-14, 20, 6);
+            camera.transform.rotation = Quaternion.Euler(90, 0, 0);
+
+            // Disable movement on the target, so that paths are not recalculated by the Movement Task
+            waypoint.GetComponent<WaypointController>().enabled = false;
+            waypoint.GetComponent<WaypointController>().StopAllCoroutines();
+
+
+            // Obstacle setup: Make it a dynamic obstacle in the NevMesh and make it move
+            obstacle.transform.position = new Vector3(-8,0.50f,3);
+            Vector3 obstacleScale = obstacle.transform.localScale;
+            obstacleScale.x = 14f;
+            obstacle.transform.localScale = obstacleScale;
+            NavMeshObstacle obsNevMesh = obstacle.AddComponent<NavMeshObstacle>();
+            obsNevMesh.carving = true;
+            obsNevMesh.carvingMoveThreshold = 0.1f;
+            obsNevMesh.carvingTimeToStationary = 0.5f;
+            obsNevMesh.carveOnlyStationary = false;
+
+            WaypointController obsController = obstacle.AddComponent<WaypointController>();
+            obsController.waitTime = 1f;
+            obsController.moveDistance = 6;
+            obsController.moveLeft = false;
+            obsController.moveRight = false;
+            
+            // Check that the obstacle was not completely ignored and the target is already reached
+            yield return new WaitForSeconds(12);
+            float distanceToWaypoint = Vector3.Distance(Agent.transform.position, waypoint.transform.position);
+            Assert.That(distanceToWaypoint, Is.GreaterThan(2f));
+            
+            // Check that the target was reached
+            yield return new WaitForSeconds(13);
+            distanceToWaypoint = Vector3.Distance(Agent.transform.position, waypoint.transform.position);
+            Assert.That(distanceToWaypoint, Is.LessThan(0.75f));
+        }
+        
         [UnityTest]
         public IEnumerator VerifySceneItem()
         {

--- a/Assets/Virtual Agents Framework/Tests/Runtime/TestAllSamples.cs
+++ b/Assets/Virtual Agents Framework/Tests/Runtime/TestAllSamples.cs
@@ -315,7 +315,11 @@ namespace i5.VirtualAgents
             var Agent = GameObject.Find("AgentStandard");
             Assert.That(Agent, Is.Not.Null);
 
-            yield return new WaitForSeconds(30);
+            yield return new WaitForSeconds(45);
+
+            // Assert that rotation Y of agent is 7.044
+            float rotationY = Agent.transform.rotation.eulerAngles.y;
+            Assert.That(rotationY, Is.EqualTo(7.044f).Within(0.5f));
 
             //TODO: Add more sample specific asserts 
         }

--- a/Assets/Virtual Agents Framework/Tests/Runtime/i5.VirtualAgents.Runtime.Tests.asmdef
+++ b/Assets/Virtual Agents Framework/Tests/Runtime/i5.VirtualAgents.Runtime.Tests.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "i5.VirtualAgents.Runtime",
-        "i5.VirtualAgents.Editor"
+        "i5.VirtualAgents.Editor",
+        "i5.VirtualAgents.Examples"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
In more complicated environments, the NavMesh Agent might need more than one frame to calculate the path. When that happens the animation of the agent goes back to idle immediately. Previously, the AgentMovementTask recalculated paths every second when it was set to follow an object, together with multi-frame path calculations, this led to the walking animation being stopped repeatedly every second. This pull request addresses this issue and other issues discovered as part of that.

Added:
- DestinationOffset in the AgentMovementTask for following objects. That option was already offered by the TaskActions, but ignored when set to follow an object.

Changed:
- When AgentMovementTask is set to follow an object, it is now recalculated only when the object moves scince the last check
- When the NavMeshAgent takes more than one frame to calculate a path to an object, the AgentAnimationUpdater.cs now keeps the last velocity magnitude value, so that the same animation keeps playing in the meantime, but without actual movement.

Fixed:
- XML Documentation in TaskActions
- Assertions/length of the rotation sample test 
