### PR TITLE
Hotfix: Fix realistic character models for sitting and item tasks

### DIFF
--- a/Assets/Virtual Agents Framework/Runtime/Prefabs/AgentBasedOnhuman001.prefab
+++ b/Assets/Virtual Agents Framework/Runtime/Prefabs/AgentBasedOnhuman001.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &80538378715115653
+--- !u!1 &92713678732003390
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,30 +8,62 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2932011570201424968}
+  - component: {fileID: 971455242581857}
   m_Layer: 0
-  m_Name: ball_r_end
+  m_Name: calf_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2932011570201424968
+--- !u!4 &971455242581857
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 80538378715115653}
+  m_GameObject: {fileID: 92713678732003390}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.052983824, y: -0.23966551, z: 0.014489394, w: 0.9693004}
+  m_LocalPosition: {x: -2.7939677e-11, y: 0.0041764732, z: -1.862645e-10}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 220231546587466067}
+  m_Father: {fileID: 7274251621029207316}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &144373103165957422
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7439491387534474585}
+  m_Layer: 0
+  m_Name: thumb_03_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7439491387534474585
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 144373103165957422}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0007129088, z: 0}
+  m_LocalPosition: {x: -0, y: 0.0003020542, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 9005895841089355381}
+  m_Father: {fileID: 1652572097934650434}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &202457056943996272
+--- !u!1 &280050862505920269
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -39,62 +71,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7708271947085719573}
+  - component: {fileID: 5821344924666519087}
   m_Layer: 0
-  m_Name: ring_03_l_end
+  m_Name: pinky_02_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7708271947085719573
+--- !u!4 &5821344924666519087
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 202457056943996272}
+  m_GameObject: {fileID: 280050862505920269}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00029037573, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3032085363824420619}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &458263756683655712
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1977091972681710427}
-  m_Layer: 0
-  m_Name: middle_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1977091972681710427
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 458263756683655712}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.045783933, y: 0.0049756006, z: -0.038089827, w: 0.9982125}
-  m_LocalPosition: {x: -2.9802322e-10, y: 0.00036860225, z: 0.000000001117587}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_LocalRotation: {x: 0.08232218, y: 0.005569877, z: -0.022216821, w: 0.99634254}
+  m_LocalPosition: {x: -0, y: 0.00023309975, z: 8.5681673e-10}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1834583825122398930}
-  m_Father: {fileID: 4708118096670987959}
+  - {fileID: 1136360121860242035}
+  m_Father: {fileID: 6355495790292457436}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &542051612692800921
+--- !u!1 &288775199318692084
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -102,633 +103,51 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 9161772437989281500}
+  - component: {fileID: 6943498800623017831}
+  - component: {fileID: 9118324405279516265}
+  - component: {fileID: 5850485884929045452}
   m_Layer: 0
-  m_Name: thumb_03_r
+  m_Name: RightBackSocket
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &9161772437989281500
+--- !u!4 &6943498800623017831
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 542051612692800921}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.14160986, y: 0.023658447, z: -0.040257353, w: 0.9888207}
-  m_LocalPosition: {x: -2.6077032e-10, y: 0.00039843097, z: 2.2351741e-10}
-  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8885656513214887453}
-  m_Father: {fileID: 5636887654003761942}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &596168397105063421
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7839319948903931383}
-  - component: {fileID: 4318089556097828895}
-  m_Layer: 0
-  m_Name: Human.tongue01.001_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7839319948903931383
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 596168397105063421}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &4318089556097828895
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 596168397105063421}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 6dfcb1430d5ed9d42b5476de99a5972e, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 8229990212890976534, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
-  m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
-  m_AABB:
-    m_Center: {x: 0, y: -0.0010296531, z: 0.015455364}
-    m_Extent: {x: 0.0002215562, y: 0.00035439502, z: 0.00014522765}
-  m_DirtyAABB: 0
---- !u!1 &636539084722892502
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6387301709469091754}
-  m_Layer: 0
-  m_Name: index_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6387301709469091754
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 636539084722892502}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.106761195, y: -0.47049862, z: 0.000018245846, w: 0.87591845}
-  m_LocalPosition: {x: 0.00014791187, y: 0.0011519569, z: 0.000089934096}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6254829604869523654}
-  m_Father: {fileID: 2153120414674204035}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &666187021780682648
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8998603658082227933}
-  m_Layer: 0
-  m_Name: lowerarm_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8998603658082227933
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666187021780682648}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.39469355, y: -0.030597242, z: -0.025556607, w: 0.91794753}
-  m_LocalPosition: {x: 0.0000000011117663, y: 0.002515248, z: -4.6566126e-11}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2153120414674204035}
-  m_Father: {fileID: 8242620225171013069}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &688739269335755094
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7909803239334512612}
-  m_Layer: 0
-  m_Name: Right Leg IK_target
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7909803239334512612
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 688739269335755094}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.8550025, y: 0.013999425, z: -0.02312513, w: 0.51791894}
-  m_LocalPosition: {x: 0.08998204, y: 0.102164164, z: -0.050898165}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 747714769927423492}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &695376131925044942
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4350913981428511573}
-  - component: {fileID: 9045746412114425870}
-  m_Layer: 0
-  m_Name: young_man.elvs_crude_t-shirt_male_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4350913981428511573
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 695376131925044942}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.00064766407, y: 1.2003242, z: 0.044049095}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &9045746412114425870
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 695376131925044942}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b630dc93918260a478aceec5bbba0c40, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -8879515619193965995, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
-  m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
-  m_AABB:
-    m_Center: {x: -0.000017681741, y: -0.0002446859, z: 0.011865951}
-    m_Extent: {x: 0.0032732002, y: 0.0018843976, z: 0.0034257895}
-  m_DirtyAABB: 0
---- !u!1 &1089407494771451711
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4108083994639100087}
-  m_Layer: 0
-  m_Name: clavicle_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4108083994639100087
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1089407494771451711}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0049917507, y: 0.04400219, z: -0.764789, w: 0.6427571}
-  m_LocalPosition: {x: 0.00022850296, y: 0.0025639683, z: 0.00092591805}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4736191973185365713}
-  m_Father: {fileID: 2194394035640687648}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1127233638375889416
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1343019073752911583}
-  - component: {fileID: 5438971196406090817}
-  m_Layer: 0
-  m_Name: CharacterRig
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1343019073752911583
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1127233638375889416}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7873583902922399994}
-  - {fileID: 355404873788954106}
-  - {fileID: 2088729375588859970}
-  - {fileID: 747714769927423492}
-  - {fileID: 5123286402344085929}
-  - {fileID: 8939403243711986005}
-  m_Father: {fileID: 45686693253767573}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5438971196406090817
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1127233638375889416}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Effectors:
-  - m_Transform: {fileID: 8278006657977749062}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 1456645604269856887}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 0, g: 0.031424046, b: 1, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 7025841333506015504}
-    m_Style:
-      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
-      color: {r: 0, g: 0.045587063, b: 1, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 3147227572165377728}
-    m_Style:
-      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
---- !u!1 &1283793698259000546
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1026906241406216219}
-  m_Layer: 0
-  m_Name: index_03_l_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1026906241406216219
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1283793698259000546}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00029122777, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3955766089117418542}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1289035118924455808
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6381475438547105264}
-  m_Layer: 0
-  m_Name: Root
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6381475438547105264
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1289035118924455808}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: -6.1001626e-10, z: 0.0000030586123}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6935857005581214143}
-  m_Father: {fileID: 8744288214721473780}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1316704128932004294
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4078266879808973118}
-  - component: {fileID: 2468873287880409299}
-  - component: {fileID: 5235368758779321558}
-  m_Layer: 0
-  m_Name: LeftBackSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4078266879808973118
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1316704128932004294}
+  m_GameObject: {fileID: 288775199318692084}
   serializedVersion: 2
   m_LocalRotation: {x: 0.72605973, y: 0.000000014901156, z: -0, w: 0.68763167}
-  m_LocalPosition: {x: -0.095, y: 1.393, z: -0.14}
+  m_LocalPosition: {x: 0.099, y: 1.393, z: -0.14}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6662995262975255089}
+  m_Father: {fileID: 6293534868797095896}
   m_LocalEulerAnglesHint: {x: 93.11401, y: 0, z: 0}
---- !u!114 &2468873287880409299
+--- !u!114 &9118324405279516265
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1316704128932004294}
+  m_GameObject: {fileID: 288775199318692084}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 7
---- !u!114 &5235368758779321558
+  <SocketId>k__BackingField: 6
+--- !u!114 &5850485884929045452
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1316704128932004294}
+  m_GameObject: {fileID: 288775199318692084}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -736,11 +155,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 4078266879808973118}
+    m_ConstrainedObject: {fileID: 6943498800623017831}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 7552695108017669976}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -773,7 +192,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &1331677249192151398
+--- !u!1 &304342067607174655
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -781,137 +200,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8939403243711986005}
-  - component: {fileID: 6293679007629449795}
-  - component: {fileID: 5261110470794954685}
-  m_Layer: 0
-  m_Name: Hip Constraint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8939403243711986005
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331677249192151398}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1343019073752911583}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6293679007629449795
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331677249192151398}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Effectors: []
---- !u!114 &5261110470794954685
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331677249192151398}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Data:
-    m_ConstrainedObject: {fileID: 0}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 0
-    m_MaintainRotationOffset: 0
---- !u!1 &1380856774159753948
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 289442066628262863}
-  m_Layer: 0
-  m_Name: thumb_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &289442066628262863
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1380856774159753948}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.14160986, y: -0.023658447, z: 0.040257353, w: 0.9888207}
-  m_LocalPosition: {x: 2.6077032e-10, y: 0.00039843097, z: 2.2351741e-10}
-  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 986349722817611106}
-  m_Father: {fileID: 6533450614167164910}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1617950525173065108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8885656513214887453}
+  - component: {fileID: 310635262587005811}
   m_Layer: 0
   m_Name: thumb_03_r_end
   m_TagString: Untagged
@@ -919,22 +208,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8885656513214887453
+--- !u!4 &310635262587005811
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1617950525173065108}
+  m_GameObject: {fileID: 304342067607174655}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0.0003020542, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 9161772437989281500}
+  m_Father: {fileID: 5189901391672644983}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1650111711880357475
+--- !u!1 &489368287163459463
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -942,51 +231,51 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1896098350468464414}
-  - component: {fileID: 8817181237433839240}
-  - component: {fileID: 2407386979603661327}
+  - component: {fileID: 2139043125419085418}
+  - component: {fileID: 7200835728092366356}
+  - component: {fileID: 894412420149666658}
   m_Layer: 0
-  m_Name: LeftLowerArmSocket
+  m_Name: HipsBackLeftSocket
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1896098350468464414
+--- !u!4 &2139043125419085418
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1650111711880357475}
+  m_GameObject: {fileID: 489368287163459463}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
-  m_LocalPosition: {x: -0.575, y: 1.387, z: -0.05}
+  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
+  m_LocalPosition: {x: -0.122, y: 1.03, z: -0.059}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6662995262975255089}
+  m_Father: {fileID: 6293534868797095896}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8817181237433839240
+--- !u!114 &7200835728092366356
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1650111711880357475}
+  m_GameObject: {fileID: 489368287163459463}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 3
---- !u!114 &2407386979603661327
+  <SocketId>k__BackingField: 10
+--- !u!114 &894412420149666658
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1650111711880357475}
+  m_GameObject: {fileID: 489368287163459463}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -994,11 +283,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 1896098350468464414}
+    m_ConstrainedObject: {fileID: 2139043125419085418}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 1836783262349754282}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -1031,7 +320,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &1797344012096047782
+--- !u!1 &548234834818707213
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1039,31 +328,33 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2702800582363756181}
+  - component: {fileID: 1836783262349754282}
   m_Layer: 0
-  m_Name: middle_02_r
+  m_Name: pelvis
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2702800582363756181
+--- !u!4 &1836783262349754282
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1797344012096047782}
+  m_GameObject: {fileID: 548234834818707213}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.045783933, y: -0.0049756006, z: 0.038089827, w: 0.9982125}
-  m_LocalPosition: {x: 2.9802322e-10, y: 0.00036860225, z: 0.000000001117587}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_LocalRotation: {x: 0.572668, y: 0, z: -0, w: 0.8197874}
+  m_LocalPosition: {x: -0, y: -0.000032745393, z: 0.00922997}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1942652714027879308}
-  m_Father: {fileID: 4700086875803376505}
+  - {fileID: 652537406475221492}
+  - {fileID: 7274251621029207316}
+  - {fileID: 948697105358146688}
+  m_Father: {fileID: 1693096230734883884}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1826141559374734896
+--- !u!1 &595275598210548066
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1071,31 +362,32 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6254829604869523654}
+  - component: {fileID: 8090927086002730634}
   m_Layer: 0
-  m_Name: index_02_l
+  m_Name: AnimationRigging
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6254829604869523654
+--- !u!4 &8090927086002730634
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1826141559374734896}
+  m_GameObject: {fileID: 595275598210548066}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.106250115, y: 0.006514418, z: -0.006954575, w: 0.9942938}
-  m_LocalPosition: {x: 2.9802322e-10, y: 0.0002830904, z: 6.705522e-10}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3955766089117418542}
-  m_Father: {fileID: 6387301709469091754}
+  - {fileID: 6293534868797095896}
+  - {fileID: 179518177863995514}
+  m_Father: {fileID: 2989011612062175184}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1910892499085722240
+--- !u!1 &771162317551486920
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1103,127 +395,120 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8278006657977749062}
+  - component: {fileID: 5198755756533146958}
   m_Layer: 0
-  m_Name: RH IK Target
+  m_Name: LH IK Hint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8278006657977749062
+--- !u!4 &5198755756533146958
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1910892499085722240}
+  m_GameObject: {fileID: 771162317551486920}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.043244947, y: -0.056759432, z: -0.70398045, w: 0.7066256}
-  m_LocalPosition: {x: 0.676, y: 1.385, z: 0.081}
-  m_LocalScale: {x: 1.0000005, y: 1.0000004, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7873583902922399994}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1953367999322655598
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5331972596041326091}
-  - component: {fileID: 4537664386814119037}
-  - component: {fileID: 7203876429196676163}
-  m_Layer: 0
-  m_Name: LeftUpperArmSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5331972596041326091
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1953367999322655598}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
-  m_LocalPosition: {x: -0.346, y: 1.386, z: -0.061}
+  m_LocalRotation: {x: 0.050784223, y: 0.06303089, z: 0.7134469, w: 0.6960184}
+  m_LocalPosition: {x: -0.295, y: 1.108, z: -0.192}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6662995262975255089}
+  m_Father: {fileID: 8936279123732570049}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4537664386814119037
+--- !u!1 &886189999577313478
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6627986633412452774}
+  m_Layer: 0
+  m_Name: index_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6627986633412452774
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 886189999577313478}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.106761195, y: 0.47049862, z: -0.000018245846, w: 0.87591845}
+  m_LocalPosition: {x: -0.00014791187, y: 0.0011519569, z: 0.000089934096}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7765029833600690865}
+  m_Father: {fileID: 8999583487048029766}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &888664401400768160
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2540796198656271744}
+  - component: {fileID: 8520051597309659016}
+  m_Layer: 0
+  m_Name: Right Arm IK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2540796198656271744
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 888664401400768160}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3151137100407803015}
+  - {fileID: 8158489380721280201}
+  m_Father: {fileID: 179518177863995514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8520051597309659016
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1953367999322655598}
+  m_GameObject: {fileID: 888664401400768160}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 4
---- !u!114 &7203876429196676163
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1953367999322655598}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
+  m_Weight: 0
   m_Data:
-    m_ConstrainedObject: {fileID: 5331972596041326091}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &1964996086454731309
+    m_Root: {fileID: 8840582609976541184}
+    m_Mid: {fileID: 517309775281467226}
+    m_Tip: {fileID: 8999583487048029766}
+    m_Target: {fileID: 3151137100407803015}
+    m_Hint: {fileID: 8158489380721280201}
+    m_TargetPositionWeight: 1
+    m_TargetRotationWeight: 1
+    m_HintWeight: 1
+    m_MaintainTargetPositionOffset: 0
+    m_MaintainTargetRotationOffset: 0
+--- !u!1 &925925592826585138
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1231,147 +516,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6820217535245325422}
-  - component: {fileID: 2651184383225062200}
-  m_Layer: 0
-  m_Name: Human.teeth_base_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6820217535245325422
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1964996086454731309}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2651184383225062200
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1964996086454731309}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 43d44152acfc6c64f95a318147ab1260, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 1537935510817236208, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
-  m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
-  m_AABB:
-    m_Center: {x: 0.0000000015716068, y: -0.0010988635, z: 0.015431106}
-    m_Extent: {x: 0.00030522048, y: 0.00039164524, z: 0.00025921548}
-  m_DirtyAABB: 0
---- !u!1 &2101203588871741269
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5123286402344085929}
-  - component: {fileID: 8390383478028786685}
-  - component: {fileID: 4191438573442981473}
+  - component: {fileID: 4834172584529499549}
+  - component: {fileID: 2533968960639802815}
+  - component: {fileID: 7663371753980581929}
   m_Layer: 0
   m_Name: Spine Aim
   m_TagString: Untagged
@@ -1379,28 +526,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5123286402344085929
+--- !u!4 &4834172584529499549
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2101203588871741269}
+  m_GameObject: {fileID: 925925592826585138}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1343019073752911583}
+  m_Father: {fileID: 179518177863995514}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8390383478028786685
+--- !u!114 &2533968960639802815
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2101203588871741269}
+  m_GameObject: {fileID: 925925592826585138}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
@@ -1408,21 +555,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 0
   m_Effectors: []
---- !u!114 &4191438573442981473
+--- !u!114 &7663371753980581929
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2101203588871741269}
+  m_GameObject: {fileID: 925925592826585138}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Weight: 1
+  m_Weight: 0
   m_Data:
-    m_ConstrainedObject: {fileID: 0}
+    m_ConstrainedObject: {fileID: 652537406475221492}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
@@ -1457,12 +604,12 @@ MonoBehaviour:
     m_WorldUpType: 0
     m_WorldUpObject: {fileID: 0}
     m_WorldUpAxis: 2
-    m_MaintainOffset: 0
+    m_MaintainOffset: 1
     m_ConstrainedAxes:
       x: 1
       y: 1
       z: 1
---- !u!1 &2130620949464326794
+--- !u!1 &951115669860926636
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1470,62 +617,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5543961444624391762}
+  - component: {fileID: 8256594702401535101}
   m_Layer: 0
-  m_Name: Right Leg IK_hint
+  m_Name: ring_03_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5543961444624391762
+--- !u!4 &8256594702401535101
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2130620949464326794}
+  m_GameObject: {fileID: 951115669860926636}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.16571209, y: 0.42413566, z: 0.77232444}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 747714769927423492}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2133637333904745363
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5855983965278827146}
-  m_Layer: 0
-  m_Name: head
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5855983965278827146
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2133637333904745363}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.1955949, y: 0, z: -0, w: 0.9806848}
-  m_LocalPosition: {x: -0, y: 0.0010318425, z: 4.842877e-10}
+  m_LocalRotation: {x: 0.06621469, y: 0.010844178, z: 0.026695766, w: 0.9973893}
+  m_LocalPosition: {x: -2.9802322e-10, y: 0.00027139983, z: -7.45058e-10}
   m_LocalScale: {x: 1, y: 0.99999994, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2992890594126987834}
-  m_Father: {fileID: 7250343783707596817}
+  - {fileID: 6244180546485434274}
+  m_Father: {fileID: 651937690382662841}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2178725148441156912
+--- !u!1 &984404952581919647
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1533,62 +649,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 581398623987264608}
+  - component: {fileID: 8637159966596288439}
   m_Layer: 0
-  m_Name: thumb_01_l
+  m_Name: ball_r_end
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &581398623987264608
+--- !u!4 &8637159966596288439
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2178725148441156912}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.27830485, y: 0.70441926, z: 0.42949465, w: -0.49180713}
-  m_LocalPosition: {x: 0.00016217268, y: 0.00043533667, z: 0.00015525124}
-  m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6533450614167164910}
-  m_Father: {fileID: 2153120414674204035}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2195923884632911941
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6682865700924935635}
-  m_Layer: 0
-  m_Name: ring_03_r_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6682865700924935635
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2195923884632911941}
+  m_GameObject: {fileID: 984404952581919647}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00029037573, z: 0}
+  m_LocalPosition: {x: -0, y: 0.0007129088, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 587083274540463616}
+  m_Father: {fileID: 1804531501257758633}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2264592681425913757
+--- !u!1 &1021049688642418057
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1596,2409 +680,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5410863296575533062}
-  m_Layer: 0
-  m_Name: pinky_03_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5410863296575533062
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2264592681425913757}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.006279758, y: -0.0037737493, z: -0.009621405, w: 0.99992687}
-  m_LocalPosition: {x: 5.9604643e-10, y: 0.00017032727, z: 1.4901161e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 972144025640631102}
-  m_Father: {fileID: 62292768086706043}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2310881633552694725
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8469696186191728788}
-  m_Layer: 0
-  m_Name: calf_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8469696186191728788
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2310881633552694725}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.052983824, y: -0.23966551, z: 0.014489394, w: 0.9693004}
-  m_LocalPosition: {x: -2.7939677e-11, y: 0.0041764732, z: -1.862645e-10}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3948862044965322662}
-  m_Father: {fileID: 5301639541042734024}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2318527193810670687
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2992890594126987834}
-  m_Layer: 0
-  m_Name: head_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2992890594126987834
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2318527193810670687}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0015566631, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5855983965278827146}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2337957772471533824
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1386433233389318046}
-  m_Layer: 0
-  m_Name: pinky_03_l_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1386433233389318046
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2337957772471533824}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00021657793, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1864852121955471862}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2359286689502997481
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6265790966222897375}
-  m_Layer: 0
-  m_Name: foot_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6265790966222897375
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2359286689502997481}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.5354672, y: -0.028092865, z: 0.021359533, w: 0.84381837}
-  m_LocalPosition: {x: 1.0739313e-10, y: 0.004351048, z: -2.3283064e-12}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9005895841089355381}
-  m_Father: {fileID: 5727524237103258722}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2479271012590699047
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5301639541042734024}
-  m_Layer: 0
-  m_Name: thigh_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5301639541042734024
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2479271012590699047}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.96511555, y: -0.08017611, z: 0.21919036, w: -0.118656375}
-  m_LocalPosition: {x: -0.0010853513, y: -0.000014180334, z: -0.0001171541}
-  m_LocalScale: {x: 1.0000002, y: 1.0000001, z: 1.0000017}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8469696186191728788}
-  m_Father: {fileID: 6935857005581214143}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2664532333831192576
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7369961263286331509}
-  m_Layer: 0
-  m_Name: Left Leg IK_target
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7369961263286331509
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2664532333831192576}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.8550024, y: -0.013999376, z: 0.02312521, w: 0.517919}
-  m_LocalPosition: {x: -0.089982, y: 0.10216425, z: -0.050898075}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2088729375588859970}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2788219975360893700
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3072447615428474384}
-  - component: {fileID: 5763629159727889447}
-  - component: {fileID: 4362429754887109512}
-  m_Layer: 0
-  m_Name: RightBackSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3072447615428474384
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2788219975360893700}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.72605973, y: 0.000000014901156, z: -0, w: 0.68763167}
-  m_LocalPosition: {x: 0.099, y: 1.393, z: -0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6662995262975255089}
-  m_LocalEulerAnglesHint: {x: 93.11401, y: 0, z: 0}
---- !u!114 &5763629159727889447
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2788219975360893700}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 6
---- !u!114 &4362429754887109512
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2788219975360893700}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 3072447615428474384}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &2858717961616140079
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 747714769927423492}
-  - component: {fileID: 6925063455267952246}
-  - component: {fileID: 3167336975816859950}
-  m_Layer: 0
-  m_Name: Right Leg IK
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &747714769927423492
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2858717961616140079}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7909803239334512612}
-  - {fileID: 5543961444624391762}
-  m_Father: {fileID: 1343019073752911583}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6925063455267952246
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2858717961616140079}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Effectors:
-  - m_Transform: {fileID: 7909803239334512612}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 5543961444624391762}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 7909803239334512612}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 5543961444624391762}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
---- !u!114 &3167336975816859950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2858717961616140079}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_Root: {fileID: 0}
-    m_Mid: {fileID: 0}
-    m_Tip: {fileID: 0}
-    m_Target: {fileID: 7909803239334512612}
-    m_Hint: {fileID: 5543961444624391762}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 0
-    m_MaintainTargetPositionOffset: 1
-    m_MaintainTargetRotationOffset: 1
---- !u!1 &2922734701594549001
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7025841333506015504}
-  m_Layer: 0
-  m_Name: LH IK Hint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7025841333506015504
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2922734701594549001}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.050784223, y: 0.06303089, z: 0.7134469, w: 0.6960184}
-  m_LocalPosition: {x: -0.295, y: 1.108, z: -0.192}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 355404873788954106}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3004251656445147438
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6170837347217371453}
-  m_Layer: 0
-  m_Name: ring_02_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6170837347217371453
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3004251656445147438}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.055358116, y: -0.0014519498, z: 0.04723631, w: 0.99734753}
-  m_LocalPosition: {x: -0, y: 0.0003247219, z: 9.685754e-10}
-  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 587083274540463616}
-  m_Father: {fileID: 5447120582929487625}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3062430007833466303
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6533450614167164910}
-  m_Layer: 0
-  m_Name: thumb_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6533450614167164910
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3062430007833466303}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.051922955, y: 0.02436226, z: 0.18687437, w: 0.9807082}
-  m_LocalPosition: {x: 1.3038516e-10, y: 0.00033529996, z: -5.587935e-10}
-  m_LocalScale: {x: 1, y: 0.99999994, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 289442066628262863}
-  m_Father: {fileID: 581398623987264608}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3203307852261745802
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8054969158496216637}
-  m_Layer: 0
-  m_Name: ring_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8054969158496216637
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3203307852261745802}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.055121828, y: -0.38169524, z: 0.22911136, w: 0.893744}
-  m_LocalPosition: {x: -0.00018935192, y: 0.0010279795, z: -0.00026482396}
-  m_LocalScale: {x: 1.0000001, y: 1, z: 0.9999998}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4625622494454960147}
-  m_Father: {fileID: 2153120414674204035}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3363748442958625057
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6006975089159664951}
-  - component: {fileID: 3959748586965247698}
-  - component: {fileID: 1012691285157303136}
-  m_Layer: 0
-  m_Name: RightLowerArmSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6006975089159664951
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3363748442958625057}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.050784193, y: -0.06303089, z: -0.713447, w: 0.6960184}
-  m_LocalPosition: {x: 0.548, y: 1.386, z: -0.045}
-  m_LocalScale: {x: 0.9999998, y: 0.99999964, z: 0.99999976}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6662995262975255089}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3959748586965247698
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3363748442958625057}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 2
---- !u!114 &1012691285157303136
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3363748442958625057}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 6006975089159664951}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &3395056996340182691
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 310669088889144333}
-  m_Layer: 0
-  m_Name: middle_03_r_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &310669088889144333
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3395056996340182691}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00029352933, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1942652714027879308}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3450800250222505314
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1755909091639234542}
-  m_Layer: 0
-  m_Name: pinky_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1755909091639234542
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3450800250222505314}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.05129042, y: 0.28181514, z: -0.2981338, w: 0.9105305}
-  m_LocalPosition: {x: 0.00037495582, y: 0.00090687256, z: -0.00034174277}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 62292768086706043}
-  m_Father: {fileID: 1525279894568953}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3741628539499065277
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3683340180554708531}
-  - component: {fileID: 6674376693476018643}
-  m_Layer: 0
-  m_Name: Human.culturalibre_hair_02_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3683340180554708531
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3741628539499065277}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &6674376693476018643
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3741628539499065277}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: da8660cde8fe5d049a7b5db89e2953ac, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 509825712720200474, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
-  m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
-  m_AABB:
-    m_Center: {x: 0.0000061546452, y: -0.00040277644, z: 0.016226392}
-    m_Extent: {x: 0.0007810689, y: 0.001226633, z: 0.0011822907}
-  m_DirtyAABB: 0
---- !u!1 &3746050033290245064
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 62292768086706043}
-  m_Layer: 0
-  m_Name: pinky_02_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &62292768086706043
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3746050033290245064}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.08232218, y: -0.005569877, z: 0.022216821, w: 0.99634254}
-  m_LocalPosition: {x: -0, y: 0.00023309975, z: 8.5681673e-10}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5410863296575533062}
-  m_Father: {fileID: 1755909091639234542}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3771922519517336442
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 45686693253767573}
-  m_Layer: 0
-  m_Name: AnimationRigging
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &45686693253767573
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3771922519517336442}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6662995262975255089}
-  - {fileID: 1343019073752911583}
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3877919638280652651
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6663741575923391351}
-  m_Layer: 0
-  m_Name: middle_03_l_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6663741575923391351
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3877919638280652651}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00029352933, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1834583825122398930}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3901776158952274208
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2088729375588859970}
-  - component: {fileID: 8537920083677104066}
-  - component: {fileID: 8464551515969690108}
-  m_Layer: 0
-  m_Name: Left Leg IK
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2088729375588859970
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3901776158952274208}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7369961263286331509}
-  - {fileID: 3659139914465126384}
-  m_Father: {fileID: 1343019073752911583}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8537920083677104066
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3901776158952274208}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Effectors:
-  - m_Transform: {fileID: 7369961263286331509}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 3659139914465126384}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 0}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 3659139914465126384}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 7369961263286331509}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 3659139914465126384}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
---- !u!114 &8464551515969690108
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3901776158952274208}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_Root: {fileID: 0}
-    m_Mid: {fileID: 0}
-    m_Tip: {fileID: 0}
-    m_Target: {fileID: 7369961263286331509}
-    m_Hint: {fileID: 3659139914465126384}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 0
-    m_MaintainTargetPositionOffset: 1
-    m_MaintainTargetRotationOffset: 1
---- !u!1 &3904387240050131454
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 519721476987846470}
-  m_Layer: 0
-  m_Name: index_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &519721476987846470
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3904387240050131454}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.106761195, y: 0.47049862, z: -0.000018245846, w: 0.87591845}
-  m_LocalPosition: {x: -0.00014791187, y: 0.0011519569, z: 0.000089934096}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6417628201332527344}
-  m_Father: {fileID: 1525279894568953}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3957913706422757178
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6448932263948215273}
-  m_Layer: 0
-  m_Name: lowerarm_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6448932263948215273
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3957913706422757178}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.39469355, y: 0.030597242, z: 0.025556607, w: 0.91794753}
-  m_LocalPosition: {x: -0.0000000011117663, y: 0.002515248, z: -4.6566126e-11}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1525279894568953}
-  m_Father: {fileID: 4736191973185365713}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4028960551880865604
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5550836990480135093}
-  - component: {fileID: 3876244169274683362}
-  m_Layer: 0
-  m_Name: Human.pants.002_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5550836990480135093
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4028960551880865604}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &3876244169274683362
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4028960551880865604}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 30228ca1642fec04db8454be525b9f03, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 3018101524230511947, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
-  m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
-  m_AABB:
-    m_Center: {x: 0.000005827984, y: -0.0001759138, z: 0.005519245}
-    m_Extent: {x: 0.0029234507, y: 0.002007253, z: 0.004964876}
-  m_DirtyAABB: 0
---- !u!1 &4156034970058965105
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1525279894568953}
-  m_Layer: 0
-  m_Name: hand_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1525279894568953
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4156034970058965105}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.10511572, y: 0.39631137, z: -0.018570323, w: 0.9118899}
-  m_LocalPosition: {x: -5.3551047e-10, y: 0.0026666406, z: -1.4901161e-10}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 519721476987846470}
-  - {fileID: 4700086875803376505}
-  - {fileID: 1755909091639234542}
-  - {fileID: 5447120582929487625}
-  - {fileID: 2482303418122539782}
-  m_Father: {fileID: 6448932263948215273}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4213770108467649737
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3948862044965322662}
-  m_Layer: 0
-  m_Name: foot_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3948862044965322662
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4213770108467649737}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.5354672, y: 0.028092865, z: -0.021359533, w: 0.84381837}
-  m_LocalPosition: {x: -1.0739313e-10, y: 0.004351048, z: -2.3283064e-12}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8799766068208656247}
-  m_Father: {fileID: 8469696186191728788}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4226819492612030563
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1864852121955471862}
-  m_Layer: 0
-  m_Name: pinky_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1864852121955471862
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4226819492612030563}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.006279758, y: 0.0037737493, z: 0.009621405, w: 0.99992687}
-  m_LocalPosition: {x: -5.9604643e-10, y: 0.00017032727, z: 1.4901161e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1386433233389318046}
-  m_Father: {fileID: 738660233367961331}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4402284298098714671
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4914579611433096830}
-  m_Layer: 0
-  m_Name: spine_01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4914579611433096830
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4402284298098714671}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.23930582, y: 0, z: -0, w: 0.9709442}
-  m_LocalPosition: {x: -0, y: 0.00092233164, z: 1.6763806e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2586261816195573327}
-  m_Father: {fileID: 6935857005581214143}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4502503299621370372
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4708118096670987959}
-  m_Layer: 0
-  m_Name: middle_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4708118096670987959
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4502503299621370372}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.09815201, y: -0.40581596, z: 0.14945257, w: 0.89629436}
-  m_LocalPosition: {x: -0.000034184715, y: 0.0011137086, z: -0.00013092316}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1977091972681710427}
-  m_Father: {fileID: 2153120414674204035}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4759931785246760133
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6662995262975255089}
-  - component: {fileID: 764515105324343442}
-  m_Layer: 0
-  m_Name: MeshSockets
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6662995262975255089
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4759931785246760133}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4120502198509109996}
-  - {fileID: 2452197676303964303}
-  - {fileID: 6006975089159664951}
-  - {fileID: 1896098350468464414}
-  - {fileID: 7122890376149638240}
-  - {fileID: 5331972596041326091}
-  - {fileID: 3072447615428474384}
-  - {fileID: 4078266879808973118}
-  - {fileID: 2704671304623688435}
-  - {fileID: 7635428384921251285}
-  - {fileID: 200451395730904519}
-  - {fileID: 4591809171619045667}
-  m_Father: {fileID: 45686693253767573}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &764515105324343442
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4759931785246760133}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Effectors: []
---- !u!1 &4822765158673822009
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3118144400904482523}
-  m_Layer: 0
-  m_Name: clavicle_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3118144400904482523
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4822765158673822009}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0049917507, y: -0.04400219, z: 0.764789, w: 0.6427571}
-  m_LocalPosition: {x: -0.00022850296, y: 0.0025639683, z: 0.00092591805}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8242620225171013069}
-  m_Father: {fileID: 2194394035640687648}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5144149690139242289
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4625622494454960147}
-  m_Layer: 0
-  m_Name: ring_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4625622494454960147
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5144149690139242289}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.055358116, y: 0.0014519498, z: -0.04723631, w: 0.99734753}
-  m_LocalPosition: {x: -0, y: 0.0003247219, z: 9.685754e-10}
-  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3032085363824420619}
-  m_Father: {fileID: 8054969158496216637}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5191580500530402405
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 738660233367961331}
-  m_Layer: 0
-  m_Name: pinky_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &738660233367961331
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5191580500530402405}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.08232218, y: 0.005569877, z: -0.022216821, w: 0.99634254}
-  m_LocalPosition: {x: -0, y: 0.00023309975, z: 8.5681673e-10}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1864852121955471862}
-  m_Father: {fileID: 5492228165484452729}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5309810982114379999
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8799766068208656247}
-  m_Layer: 0
-  m_Name: ball_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8799766068208656247
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5309810982114379999}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.25208107, y: 0.24984322, z: -0.10381857, w: 0.9291153}
-  m_LocalPosition: {x: -2.0663719e-11, y: 0.0014053999, z: 7.4505804e-11}
-  m_LocalScale: {x: 0.9999999, y: 0.9999999, z: 0.9999999}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8022631395622748485}
-  m_Father: {fileID: 3948862044965322662}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5389761216941140835
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2586261816195573327}
-  m_Layer: 0
-  m_Name: spine_02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2586261816195573327
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5389761216941140835}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.13355094, y: 0, z: -0, w: 0.99104196}
-  m_LocalPosition: {x: -0, y: 0.0007041444, z: 3.7252902e-11}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2194394035640687648}
-  m_Father: {fileID: 4914579611433096830}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5476425239981584224
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2482303418122539782}
-  m_Layer: 0
-  m_Name: thumb_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2482303418122539782
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5476425239981584224}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.27830485, y: 0.70441926, z: 0.42949465, w: 0.49180713}
-  m_LocalPosition: {x: -0.00016217268, y: 0.00043533667, z: 0.00015525124}
-  m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5636887654003761942}
-  m_Father: {fileID: 1525279894568953}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5601413334001947015
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6417628201332527344}
-  m_Layer: 0
-  m_Name: index_02_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6417628201332527344
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5601413334001947015}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.106250115, y: -0.006514418, z: 0.006954575, w: 0.9942938}
-  m_LocalPosition: {x: -2.9802322e-10, y: 0.0002830904, z: 6.705522e-10}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3107829411805174822}
-  m_Father: {fileID: 519721476987846470}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5613982476285610803
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2153120414674204035}
-  m_Layer: 0
-  m_Name: hand_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2153120414674204035
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5613982476285610803}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.10511572, y: -0.39631137, z: 0.018570323, w: 0.9118899}
-  m_LocalPosition: {x: 5.3551047e-10, y: 0.0026666406, z: -1.4901161e-10}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6387301709469091754}
-  - {fileID: 4708118096670987959}
-  - {fileID: 5492228165484452729}
-  - {fileID: 8054969158496216637}
-  - {fileID: 581398623987264608}
-  m_Father: {fileID: 8998603658082227933}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5763539582720440238
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 587083274540463616}
-  m_Layer: 0
-  m_Name: ring_03_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &587083274540463616
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5763539582720440238}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.06621469, y: -0.010844178, z: -0.026695766, w: 0.9973893}
-  m_LocalPosition: {x: 2.9802322e-10, y: 0.00027139983, z: -7.45058e-10}
-  m_LocalScale: {x: 1, y: 0.99999994, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6682865700924935635}
-  m_Father: {fileID: 6170837347217371453}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5870006384165531398
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1942652714027879308}
-  m_Layer: 0
-  m_Name: middle_03_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1942652714027879308
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5870006384165531398}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0678251, y: -0.0045507005, z: -0.005374984, w: 0.9976724}
-  m_LocalPosition: {x: -0, y: 0.00029987044, z: -4.4703483e-10}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 310669088889144333}
-  m_Father: {fileID: 2702800582363756181}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5876347529049004901
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 200451395730904519}
-  - component: {fileID: 5415776379724441375}
-  - component: {fileID: 2579777073245026183}
-  m_Layer: 0
-  m_Name: HipsFrontRightSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &200451395730904519
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5876347529049004901}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
-  m_LocalPosition: {x: 0.081, y: 0.985, z: 0.107}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6662995262975255089}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5415776379724441375
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5876347529049004901}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 9
---- !u!114 &2579777073245026183
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5876347529049004901}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 200451395730904519}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &6056871111557764014
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3659139914465126384}
-  m_Layer: 0
-  m_Name: Left Leg IK_hint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3659139914465126384
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6056871111557764014}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.16571158, y: 0.42413455, z: 0.7723244}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2088729375588859970}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6144208187602893807
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2452197676303964303}
-  - component: {fileID: 2806222388072346070}
-  - component: {fileID: 4967724960380856633}
-  m_Layer: 0
-  m_Name: LeftHandSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2452197676303964303
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6144208187602893807}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
-  m_LocalPosition: {x: -0.802, y: 1.353, z: -0.017}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6662995262975255089}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2806222388072346070
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6144208187602893807}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 1
---- !u!114 &4967724960380856633
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6144208187602893807}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 2452197676303964303}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &6191604735640126349
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7635428384921251285}
-  - component: {fileID: 6703914689398496867}
-  - component: {fileID: 8673920496773331623}
-  m_Layer: 0
-  m_Name: HipsBackRightSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7635428384921251285
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6191604735640126349}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
-  m_LocalPosition: {x: 0.078, y: 1.034, z: -0.076}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6662995262975255089}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6703914689398496867
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6191604735640126349}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 11
---- !u!114 &8673920496773331623
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6191604735640126349}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 7635428384921251285}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &6193040898889798941
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8744288214721473780}
-  m_Layer: 0
-  m_Name: Human.001.rig_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8744288214721473780
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6193040898889798941}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 100, y: 100, z: 100}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6381475438547105264}
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6281468226317537172
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4736802005887745609}
-  - component: {fileID: 5855255662139935315}
-  m_Layer: 0
-  m_Name: Human.low-poly.001_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4736802005887745609
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6281468226317537172}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &5855255662139935315
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6281468226317537172}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: ff26a6916d844834f9f0d93ebec56b5e, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -9063650396101244781, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
-  m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
-  m_AABB:
-    m_Center: {x: 0, y: -0.001302408, z: 0.016203536}
-    m_Extent: {x: 0.00044132542, y: 0.0001255651, z: 0.00014419295}
-  m_DirtyAABB: 0
---- !u!1 &6412597854614029653
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5636887654003761942}
-  m_Layer: 0
-  m_Name: thumb_02_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5636887654003761942
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6412597854614029653}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.051922955, y: -0.02436226, z: -0.18687437, w: 0.9807082}
-  m_LocalPosition: {x: -1.3038516e-10, y: 0.00033529996, z: -5.587935e-10}
-  m_LocalScale: {x: 1, y: 0.99999994, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9161772437989281500}
-  m_Father: {fileID: 2482303418122539782}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6417204539044379843
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1670803027647774345}
-  m_Layer: 0
-  m_Name: thigh_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1670803027647774345
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6417204539044379843}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.96511555, y: 0.08017611, z: -0.21919036, w: -0.118656375}
-  m_LocalPosition: {x: 0.0010853513, y: -0.000014180334, z: -0.0001171541}
-  m_LocalScale: {x: 1.0000002, y: 1.0000001, z: 1.0000017}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5727524237103258722}
-  m_Father: {fileID: 6935857005581214143}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6511970353811707683
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4736191973185365713}
-  m_Layer: 0
-  m_Name: upperarm_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4736191973185365713
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6511970353811707683}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.01312217, y: 0.02405169, z: -0.3310979, w: 0.94319856}
-  m_LocalPosition: {x: 1.9790605e-11, y: 0.00165996, z: -1.3038516e-10}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6448932263948215273}
-  m_Father: {fileID: 4108083994639100087}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6547043745401402271
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1791206551703019591}
-  - component: {fileID: 6768789156876159689}
+  - component: {fileID: 566189503457441254}
+  - component: {fileID: 5811415062503345429}
   m_Layer: 0
   m_Name: Human.eyebrow012_export_copy
   m_TagString: Untagged
@@ -4006,28 +689,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1791206551703019591
+--- !u!4 &566189503457441254
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6547043745401402271}
+  m_GameObject: {fileID: 1021049688642418057}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4749814036626849447}
+  m_Father: {fileID: 2989011612062175184}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &6768789156876159689
+--- !u!137 &5811415062503345429
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6547043745401402271}
+  m_GameObject: {fileID: 1021049688642418057}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -4038,6 +721,11 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4059,75 +747,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 9129081289075417173, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
   m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
+  m_RootBone: {fileID: 1693096230734883884}
   m_AABB:
     m_Center: {x: 0, y: -0.0013684419, z: 0.016289106}
     m_Extent: {x: 0.00057961466, y: 0.00014872593, z: 0.00009078905}
   m_DirtyAABB: 0
---- !u!1 &6665584947981106430
+--- !u!1 &1081303461941886765
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4135,33 +825,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6935857005581214143}
+  - component: {fileID: 68161147633687569}
   m_Layer: 0
-  m_Name: pelvis
+  m_Name: head_end
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6935857005581214143
+--- !u!4 &68161147633687569
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6665584947981106430}
+  m_GameObject: {fileID: 1081303461941886765}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.572668, y: 0, z: -0, w: 0.8197874}
-  m_LocalPosition: {x: -0, y: -0.000032745393, z: 0.00922997}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0015566631, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4914579611433096830}
-  - {fileID: 5301639541042734024}
-  - {fileID: 1670803027647774345}
-  m_Father: {fileID: 6381475438547105264}
+  m_Children: []
+  m_Father: {fileID: 2523300434971526762}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7003174453036956495
+--- !u!1 &1301503251642269155
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4169,9 +856,142 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7122890376149638240}
-  - component: {fileID: 1662317406926204081}
-  - component: {fileID: 6991684081875841661}
+  - component: {fileID: 6400664125520123407}
+  - component: {fileID: 4947143583067680178}
+  - component: {fileID: 8384685216991937709}
+  m_Layer: 0
+  m_Name: LeftLowerArmSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6400664125520123407
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1301503251642269155}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
+  m_LocalPosition: {x: -0.35143352, y: 1.1890961, z: 0.015590668}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6293534868797095896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4947143583067680178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1301503251642269155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 3
+--- !u!114 &8384685216991937709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1301503251642269155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 6400664125520123407}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 8748112956975368665}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &1314835660295843740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8999583487048029766}
+  m_Layer: 0
+  m_Name: hand_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8999583487048029766
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1314835660295843740}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.10511572, y: 0.39631137, z: -0.018570323, w: 0.9118899}
+  m_LocalPosition: {x: -5.3551047e-10, y: 0.0026666406, z: -1.4901161e-10}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6627986633412452774}
+  - {fileID: 5131297903608675152}
+  - {fileID: 2574208233736228566}
+  - {fileID: 8267148477398227571}
+  - {fileID: 75155874047189440}
+  m_Father: {fileID: 517309775281467226}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1359015673284225497
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7320151553043424382}
+  - component: {fileID: 5624567191214147510}
+  - component: {fileID: 3592300477620086417}
   m_Layer: 0
   m_Name: RightUpperArmSocket
   m_TagString: Untagged
@@ -4179,41 +999,41 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7122890376149638240
+--- !u!4 &7320151553043424382
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7003174453036956495}
+  m_GameObject: {fileID: 1359015673284225497}
   serializedVersion: 2
   m_LocalRotation: {x: 0.050784163, y: -0.06303089, z: -0.713447, w: 0.69601834}
-  m_LocalPosition: {x: 0.322, y: 1.391, z: -0.082}
+  m_LocalPosition: {x: 0.1861217, y: 1.3786533, z: 0.01777029}
   m_LocalScale: {x: 0.9999998, y: 0.99999964, z: 0.99999976}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6662995262975255089}
+  m_Father: {fileID: 6293534868797095896}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1662317406926204081
+--- !u!114 &5624567191214147510
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7003174453036956495}
+  m_GameObject: {fileID: 1359015673284225497}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   <SocketId>k__BackingField: 5
---- !u!114 &6991684081875841661
+--- !u!114 &3592300477620086417
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7003174453036956495}
+  m_GameObject: {fileID: 1359015673284225497}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -4221,11 +1041,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 7122890376149638240}
+    m_ConstrainedObject: {fileID: 7320151553043424382}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 8840582609976541184}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -4258,7 +1078,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &7062490137135910515
+--- !u!1 &1368164213775733976
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4266,68 +1086,37 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8022631395622748485}
+  - component: {fileID: 5342031102609170254}
+  - component: {fileID: 9007358090981108953}
   m_Layer: 0
-  m_Name: ball_l_end
+  m_Name: young_man.elvs_crude_t-shirt_male_export_copy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8022631395622748485
+--- !u!4 &5342031102609170254
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7062490137135910515}
+  m_GameObject: {fileID: 1368164213775733976}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0007129088, z: 0}
+  m_LocalPosition: {x: 0, y: 1.2003242, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8799766068208656247}
+  m_Father: {fileID: 2989011612062175184}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7108412633631616491
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8737835994182091433}
-  - component: {fileID: 8723520260637092873}
-  m_Layer: 0
-  m_Name: Human.eyelashes01_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8737835994182091433
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7108412633631616491}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &8723520260637092873
+--- !u!137 &9007358090981108953
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7108412633631616491}
+  m_GameObject: {fileID: 1368164213775733976}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -4338,10 +1127,15 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 422b5d3233594cb4b8199078557082ba, type: 2}
+  - {fileID: 2100000, guid: b630dc93918260a478aceec5bbba0c40, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -4359,75 +1153,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -5903601820808268019, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
+  m_Mesh: {fileID: -8879515619193965995, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
   m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
+  m_RootBone: {fileID: 1693096230734883884}
   m_AABB:
-    m_Center: {x: 0, y: -0.0014064594, z: 0.016175518}
-    m_Extent: {x: 0.00048225332, y: 0.00007532316, z: 0.00007107109}
+    m_Center: {x: -0.000017681741, y: -0.0002446859, z: 0.011865951}
+    m_Extent: {x: 0.0032732002, y: 0.0018843976, z: 0.0034257895}
   m_DirtyAABB: 0
---- !u!1 &7211578244802569348
+--- !u!1 &1386540965355663368
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4435,30 +1231,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 972144025640631102}
+  - component: {fileID: 7765029833600690865}
   m_Layer: 0
-  m_Name: pinky_03_r_end
+  m_Name: index_02_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &972144025640631102
+--- !u!4 &7765029833600690865
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7211578244802569348}
+  m_GameObject: {fileID: 1386540965355663368}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00021657793, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: 0.106250115, y: -0.006514418, z: 0.006954575, w: 0.9942938}
+  m_LocalPosition: {x: -2.9802322e-10, y: 0.0002830904, z: 6.705522e-10}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5410863296575533062}
+  m_Children:
+  - {fileID: 2725790562469233658}
+  m_Father: {fileID: 6627986633412452774}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7212289528139096341
+--- !u!1 &1535392704796663675
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4466,7 +1263,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 9005895841089355381}
+  - component: {fileID: 1804531501257758633}
   m_Layer: 0
   m_Name: ball_r
   m_TagString: Untagged
@@ -4474,23 +1271,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &9005895841089355381
+--- !u!4 &1804531501257758633
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7212289528139096341}
+  m_GameObject: {fileID: 1535392704796663675}
   serializedVersion: 2
   m_LocalRotation: {x: -0.25208107, y: -0.24984322, z: 0.10381857, w: 0.9291153}
   m_LocalPosition: {x: 2.0663719e-11, y: 0.0014053999, z: 7.4505804e-11}
   m_LocalScale: {x: 0.9999999, y: 0.9999999, z: 0.9999999}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2932011570201424968}
-  m_Father: {fileID: 6265790966222897375}
+  - {fileID: 8637159966596288439}
+  m_Father: {fileID: 487789334998833700}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7266995942945496222
+--- !u!1 &1568225421259510299
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4498,400 +1295,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2704671304623688435}
-  - component: {fileID: 1354114585489124001}
-  - component: {fileID: 7443041836645678869}
-  m_Layer: 0
-  m_Name: HipsBackLeftSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2704671304623688435
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7266995942945496222}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
-  m_LocalPosition: {x: -0.122, y: 1.03, z: -0.059}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6662995262975255089}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1354114585489124001
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7266995942945496222}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 10
---- !u!114 &7443041836645678869
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7266995942945496222}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 2704671304623688435}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &7311980972976386905
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3147227572165377728}
-  m_Layer: 0
-  m_Name: RH IK Hint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3147227572165377728
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7311980972976386905}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.050784223, y: 0.06303089, z: 0.7134469, w: 0.6960184}
-  m_LocalPosition: {x: 0.281, y: 1.122, z: -0.286}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7873583902922399994}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7322582499002675180
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4700086875803376505}
-  m_Layer: 0
-  m_Name: middle_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4700086875803376505
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7322582499002675180}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.09815201, y: 0.40581596, z: -0.14945257, w: 0.89629436}
-  m_LocalPosition: {x: 0.000034184715, y: 0.0011137086, z: -0.00013092316}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2702800582363756181}
-  m_Father: {fileID: 1525279894568953}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7446438535471110546
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 599570897989283192}
-  - component: {fileID: 5141916909569185503}
-  m_Layer: 0
-  m_Name: Human.001_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &599570897989283192
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7446438535471110546}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4749814036626849447}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &5141916909569185503
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7446438535471110546}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 7f52966192a013c4983c2914b0ca9805, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 1083055858737764333, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
-  m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
-  m_AABB:
-    m_Center: {x: 0.000019436935, y: -0.0008920174, z: 0.00924103}
-    m_Extent: {x: 0.0057960264, y: 0.0029261298, z: 0.008094355}
-  m_DirtyAABB: 0
---- !u!1 &7593466363642613723
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1834583825122398930}
-  m_Layer: 0
-  m_Name: middle_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1834583825122398930
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7593466363642613723}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0678251, y: 0.0045507005, z: 0.005374984, w: 0.9976724}
-  m_LocalPosition: {x: -0, y: 0.00029987044, z: -4.4703483e-10}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6663741575923391351}
-  m_Father: {fileID: 1977091972681710427}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7605438720158934838
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1456645604269856887}
-  m_Layer: 0
-  m_Name: LH IK Target
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1456645604269856887
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7605438720158934838}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.043244887, y: 0.05675955, z: 0.7039805, w: 0.7066255}
-  m_LocalPosition: {x: -0.867, y: 1.383, z: 0.007}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 355404873788954106}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7630530329664598091
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3553457148762261971}
-  m_Layer: 0
-  m_Name: index_03_r_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3553457148762261971
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7630530329664598091}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00029122777, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3107829411805174822}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7857828755931245713
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2016040959044072176}
-  - component: {fileID: 2962307583326769051}
+  - component: {fileID: 1409953973312936873}
+  - component: {fileID: 3323513338827627479}
   m_Layer: 0
   m_Name: Human.shoes03.001_export_copy
   m_TagString: Untagged
@@ -4899,28 +1304,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2016040959044072176
+--- !u!4 &1409953973312936873
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7857828755931245713}
+  m_GameObject: {fileID: 1568225421259510299}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4749814036626849447}
+  m_Father: {fileID: 2989011612062175184}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2962307583326769051
+--- !u!137 &3323513338827627479
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7857828755931245713}
+  m_GameObject: {fileID: 1568225421259510299}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -4931,6 +1336,11 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4952,75 +1362,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -3877949562630557322, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
   m_Bones:
-  - {fileID: 6381475438547105264}
-  - {fileID: 6935857005581214143}
-  - {fileID: 4914579611433096830}
-  - {fileID: 2586261816195573327}
-  - {fileID: 2194394035640687648}
-  - {fileID: 3118144400904482523}
-  - {fileID: 8242620225171013069}
-  - {fileID: 8998603658082227933}
-  - {fileID: 2153120414674204035}
-  - {fileID: 6387301709469091754}
-  - {fileID: 6254829604869523654}
-  - {fileID: 3955766089117418542}
-  - {fileID: 4708118096670987959}
-  - {fileID: 1977091972681710427}
-  - {fileID: 1834583825122398930}
-  - {fileID: 5492228165484452729}
-  - {fileID: 738660233367961331}
-  - {fileID: 1864852121955471862}
-  - {fileID: 8054969158496216637}
-  - {fileID: 4625622494454960147}
-  - {fileID: 3032085363824420619}
-  - {fileID: 581398623987264608}
-  - {fileID: 6533450614167164910}
-  - {fileID: 289442066628262863}
-  - {fileID: 4108083994639100087}
-  - {fileID: 4736191973185365713}
-  - {fileID: 6448932263948215273}
-  - {fileID: 1525279894568953}
-  - {fileID: 519721476987846470}
-  - {fileID: 6417628201332527344}
-  - {fileID: 3107829411805174822}
-  - {fileID: 4700086875803376505}
-  - {fileID: 2702800582363756181}
-  - {fileID: 1942652714027879308}
-  - {fileID: 1755909091639234542}
-  - {fileID: 62292768086706043}
-  - {fileID: 5410863296575533062}
-  - {fileID: 5447120582929487625}
-  - {fileID: 6170837347217371453}
-  - {fileID: 587083274540463616}
-  - {fileID: 2482303418122539782}
-  - {fileID: 5636887654003761942}
-  - {fileID: 9161772437989281500}
-  - {fileID: 7250343783707596817}
-  - {fileID: 5855983965278827146}
-  - {fileID: 5301639541042734024}
-  - {fileID: 8469696186191728788}
-  - {fileID: 3948862044965322662}
-  - {fileID: 8799766068208656247}
-  - {fileID: 1670803027647774345}
-  - {fileID: 5727524237103258722}
-  - {fileID: 6265790966222897375}
-  - {fileID: 9005895841089355381}
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 6381475438547105264}
+  m_RootBone: {fileID: 1693096230734883884}
   m_AABB:
     m_Center: {x: 0, y: -0.00058664073, z: 0.0006632335}
     m_Extent: {x: 0.003141093, y: 0.0019313877, z: 0.0018018507}
   m_DirtyAABB: 0
---- !u!1 &8027190347430570336
+--- !u!1 &1571287515369089725
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5028,96 +1440,61 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4120502198509109996}
-  - component: {fileID: 6024104120658663933}
-  - component: {fileID: 1658650133964228844}
+  - component: {fileID: 7183150599398145676}
   m_Layer: 0
-  m_Name: RightHandSocket
+  m_Name: Right Leg IK_target
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4120502198509109996
+--- !u!4 &7183150599398145676
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8027190347430570336}
+  m_GameObject: {fileID: 1571287515369089725}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.04324497, y: -0.056759395, z: -0.70398045, w: 0.7066256}
-  m_LocalPosition: {x: 0.787, y: 1.355, z: 0.005}
+  m_LocalRotation: {x: 0.8550025, y: 0.013999425, z: -0.02312513, w: 0.51791894}
+  m_LocalPosition: {x: 0.08998204, y: 0.102164164, z: -0.050898165}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 834849821424450799}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1698097326478012436
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8158489380721280201}
+  m_Layer: 0
+  m_Name: RH IK Hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8158489380721280201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1698097326478012436}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.050784223, y: 0.06303089, z: 0.7134469, w: 0.6960184}
+  m_LocalPosition: {x: 0.281, y: 1.122, z: -0.286}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6662995262975255089}
+  m_Father: {fileID: 2540796198656271744}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6024104120658663933
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8027190347430570336}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 0
---- !u!114 &1658650133964228844
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8027190347430570336}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 4120502198509109996}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &8166531599234640076
+--- !u!1 &1706400890658603254
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5125,314 +1502,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 986349722817611106}
-  m_Layer: 0
-  m_Name: thumb_03_l_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &986349722817611106
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8166531599234640076}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0003020542, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 289442066628262863}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8183886414576337550
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7873583902922399994}
-  - component: {fileID: 1377062839725788164}
-  m_Layer: 0
-  m_Name: Right Arm IK
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7873583902922399994
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8183886414576337550}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8278006657977749062}
-  - {fileID: 3147227572165377728}
-  m_Father: {fileID: 1343019073752911583}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1377062839725788164
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8183886414576337550}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Data:
-    m_Root: {fileID: 4736191973185365713}
-    m_Mid: {fileID: 6448932263948215273}
-    m_Tip: {fileID: 1525279894568953}
-    m_Target: {fileID: 8278006657977749062}
-    m_Hint: {fileID: 3147227572165377728}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 1
-    m_MaintainTargetPositionOffset: 0
-    m_MaintainTargetRotationOffset: 0
---- !u!1 &8241326017230118261
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5727524237103258722}
-  m_Layer: 0
-  m_Name: calf_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5727524237103258722
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8241326017230118261}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.052983824, y: 0.23966551, z: -0.014489394, w: 0.9693004}
-  m_LocalPosition: {x: 2.7939677e-11, y: 0.0041764732, z: -1.862645e-10}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6265790966222897375}
-  m_Father: {fileID: 1670803027647774345}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8300738060662716911
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8242620225171013069}
-  m_Layer: 0
-  m_Name: upperarm_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8242620225171013069
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8300738060662716911}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.01312217, y: -0.02405169, z: 0.3310979, w: 0.94319856}
-  m_LocalPosition: {x: -1.9790605e-11, y: 0.00165996, z: -1.3038516e-10}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8998603658082227933}
-  m_Father: {fileID: 3118144400904482523}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8387616030573765386
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7250343783707596817}
-  m_Layer: 0
-  m_Name: neck_01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7250343783707596817
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8387616030573765386}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.25270265, y: 0, z: -0, w: 0.967544}
-  m_LocalPosition: {x: -0, y: 0.003317179, z: 0.0009271641}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5855983965278827146}
-  m_Father: {fileID: 2194394035640687648}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8419907894371085355
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3107829411805174822}
-  m_Layer: 0
-  m_Name: index_03_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3107829411805174822
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8419907894371085355}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.06060502, y: 0.00016188687, z: 0.016979786, w: 0.9980174}
-  m_LocalPosition: {x: 2.9802322e-10, y: 0.0002536689, z: -2.9802322e-10}
-  m_LocalScale: {x: 1, y: 0.9999998, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3553457148762261971}
-  m_Father: {fileID: 6417628201332527344}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8435818850776768396
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 355404873788954106}
-  - component: {fileID: 6967384933256025995}
-  m_Layer: 0
-  m_Name: Left Arm IK
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &355404873788954106
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8435818850776768396}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1456645604269856887}
-  - {fileID: 7025841333506015504}
-  m_Father: {fileID: 1343019073752911583}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6967384933256025995
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8435818850776768396}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Data:
-    m_Root: {fileID: 8242620225171013069}
-    m_Mid: {fileID: 8998603658082227933}
-    m_Tip: {fileID: 2153120414674204035}
-    m_Target: {fileID: 1456645604269856887}
-    m_Hint: {fileID: 7025841333506015504}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 1
-    m_MaintainTargetPositionOffset: 0
-    m_MaintainTargetRotationOffset: 0
---- !u!1 &8481696167270328025
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3032085363824420619}
-  m_Layer: 0
-  m_Name: ring_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3032085363824420619
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8481696167270328025}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.06621469, y: 0.010844178, z: 0.026695766, w: 0.9973893}
-  m_LocalPosition: {x: -2.9802322e-10, y: 0.00027139983, z: -7.45058e-10}
-  m_LocalScale: {x: 1, y: 0.99999994, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7708271947085719573}
-  m_Father: {fileID: 4625622494454960147}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8603991696419299056
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5447120582929487625}
+  - component: {fileID: 8267148477398227571}
   m_Layer: 0
   m_Name: ring_01_r
   m_TagString: Untagged
@@ -5440,23 +1510,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5447120582929487625
+--- !u!4 &8267148477398227571
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8603991696419299056}
+  m_GameObject: {fileID: 1706400890658603254}
   serializedVersion: 2
   m_LocalRotation: {x: 0.055121828, y: 0.38169524, z: -0.22911136, w: 0.893744}
   m_LocalPosition: {x: 0.00018935192, y: 0.0010279795, z: -0.00026482396}
   m_LocalScale: {x: 1.0000001, y: 1, z: 0.9999998}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6170837347217371453}
-  m_Father: {fileID: 1525279894568953}
+  - {fileID: 3965339155065461346}
+  m_Father: {fileID: 8999583487048029766}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8836332032270886446
+--- !u!1 &1811930281939135703
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5464,33 +1534,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2194394035640687648}
+  - component: {fileID: 5513135449600759724}
   m_Layer: 0
-  m_Name: spine_03
+  m_Name: index_03_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2194394035640687648
+--- !u!4 &5513135449600759724
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8836332032270886446}
+  m_GameObject: {fileID: 1811930281939135703}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.011703165, y: 0, z: -0, w: 0.9999315}
-  m_LocalPosition: {x: -0, y: 0.0006111533, z: -9.313225e-11}
-  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
+  m_LocalRotation: {x: 0.06060502, y: -0.00016188687, z: -0.016979786, w: 0.9980174}
+  m_LocalPosition: {x: -2.9802322e-10, y: 0.0002536689, z: -2.9802322e-10}
+  m_LocalScale: {x: 1, y: 0.9999998, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3118144400904482523}
-  - {fileID: 4108083994639100087}
-  - {fileID: 7250343783707596817}
-  m_Father: {fileID: 2586261816195573327}
+  - {fileID: 7215238448763726459}
+  m_Father: {fileID: 6668574397246592601}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8993158450277161135
+--- !u!1 &1919776957193001240
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5498,9 +1566,154 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4591809171619045667}
-  - component: {fileID: 8833374915045415858}
-  - component: {fileID: 8033844804199032189}
+  - component: {fileID: 63478134055451994}
+  - component: {fileID: 8551066738572528368}
+  m_Layer: 0
+  m_Name: Human.001_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &63478134055451994
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919776957193001240}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2989011612062175184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &8551066738572528368
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919776957193001240}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7f52966192a013c4983c2914b0ca9805, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 1083055858737764333, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
+  m_Bones:
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 1693096230734883884}
+  m_AABB:
+    m_Center: {x: 0.000019436935, y: -0.0008920174, z: 0.00924103}
+    m_Extent: {x: 0.0057960264, y: 0.0029261298, z: 0.008094355}
+  m_DirtyAABB: 0
+--- !u!1 &2023748718547323300
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7493483055195106130}
+  - component: {fileID: 4688926332994518855}
+  - component: {fileID: 4534489606826301553}
   m_Layer: 0
   m_Name: HipsFrontLeftSocket
   m_TagString: Untagged
@@ -5508,41 +1721,41 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4591809171619045667
+--- !u!4 &7493483055195106130
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8993158450277161135}
+  m_GameObject: {fileID: 2023748718547323300}
   serializedVersion: 2
   m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
   m_LocalPosition: {x: -0.141, y: 1.001, z: 0.091}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6662995262975255089}
+  m_Father: {fileID: 6293534868797095896}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8833374915045415858
+--- !u!114 &4688926332994518855
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8993158450277161135}
+  m_GameObject: {fileID: 2023748718547323300}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   <SocketId>k__BackingField: 8
---- !u!114 &8033844804199032189
+--- !u!114 &4534489606826301553
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8993158450277161135}
+  m_GameObject: {fileID: 2023748718547323300}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -5550,11 +1763,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 4591809171619045667}
+    m_ConstrainedObject: {fileID: 7493483055195106130}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 1836783262349754282}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -5587,7 +1800,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &9167154681844139308
+--- !u!1 &2204643281758930225
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5595,31 +1808,83 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3955766089117418542}
+  - component: {fileID: 179518177863995514}
+  - component: {fileID: 4265270270235904556}
   m_Layer: 0
-  m_Name: index_03_l
+  m_Name: CharacterRig
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3955766089117418542
+--- !u!4 &179518177863995514
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9167154681844139308}
+  m_GameObject: {fileID: 2204643281758930225}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.06060502, y: -0.00016188687, z: -0.016979786, w: 0.9980174}
-  m_LocalPosition: {x: -2.9802322e-10, y: 0.0002536689, z: -2.9802322e-10}
-  m_LocalScale: {x: 1, y: 0.9999998, z: 0.99999994}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1026906241406216219}
-  m_Father: {fileID: 6254829604869523654}
+  - {fileID: 2540796198656271744}
+  - {fileID: 8936279123732570049}
+  - {fileID: 6608349870156286876}
+  - {fileID: 4711015368239245717}
+  - {fileID: 834849821424450799}
+  - {fileID: 4834172584529499549}
+  m_Father: {fileID: 8090927086002730634}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &9195597944749937307
+--- !u!114 &4265270270235904556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2204643281758930225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Effectors:
+  - m_Transform: {fileID: 3151137100407803015}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 3834684462413917049}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 0, g: 0.031424046, b: 1, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 5198755756533146958}
+    m_Style:
+      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
+      color: {r: 0, g: 0.045587063, b: 1, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 8158489380721280201}
+    m_Style:
+      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!1 &2213965116564463787
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5627,7 +1892,2514 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5492228165484452729}
+  - component: {fileID: 4269926664162362132}
+  m_Layer: 0
+  m_Name: pinky_03_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4269926664162362132
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2213965116564463787}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00021657793, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1136360121860242035}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2339381340037185285
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8107239698850677341}
+  m_Layer: 0
+  m_Name: middle_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8107239698850677341
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2339381340037185285}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0678251, y: 0.0045507005, z: 0.005374984, w: 0.9976724}
+  m_LocalPosition: {x: -0, y: 0.00029987044, z: -4.4703483e-10}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3613427011463542475}
+  m_Father: {fileID: 6850267919126700859}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2456217540991407858
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2498745504765516371}
+  - component: {fileID: 2361126954886032728}
+  - component: {fileID: 8029910805771256681}
+  m_Layer: 0
+  m_Name: RightHandSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2498745504765516371
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2456217540991407858}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.04324497, y: -0.056759395, z: -0.70398045, w: 0.7066256}
+  m_LocalPosition: {x: 0.5097, y: 1.0033, z: 0.2507}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6293534868797095896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2361126954886032728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2456217540991407858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 0
+--- !u!114 &8029910805771256681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2456217540991407858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 2498745504765516371}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 8999583487048029766}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &2568280962123680702
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7571026651442612078}
+  m_Layer: 0
+  m_Name: pinky_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7571026651442612078
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2568280962123680702}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.006279758, y: -0.0037737493, z: -0.009621405, w: 0.99992687}
+  m_LocalPosition: {x: 5.9604643e-10, y: 0.00017032727, z: 1.4901161e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4981113335983373325}
+  m_Father: {fileID: 7074783327219614238}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2712513397355836580
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5289082858968763830}
+  m_Layer: 0
+  m_Name: middle_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5289082858968763830
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2712513397355836580}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0678251, y: -0.0045507005, z: -0.005374984, w: 0.9976724}
+  m_LocalPosition: {x: -0, y: 0.00029987044, z: -4.4703483e-10}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3223582963681919740}
+  m_Father: {fileID: 8687739253276426027}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2847228427403923820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5487360084104021522}
+  - component: {fileID: 7749338126910162075}
+  m_Layer: 0
+  m_Name: Human.culturalibre_hair_02_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5487360084104021522
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2847228427403923820}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2989011612062175184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &7749338126910162075
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2847228427403923820}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: da8660cde8fe5d049a7b5db89e2953ac, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 509825712720200474, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
+  m_Bones:
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 1693096230734883884}
+  m_AABB:
+    m_Center: {x: 0.0000061546452, y: -0.00040277644, z: 0.016226392}
+    m_Extent: {x: 0.0007810689, y: 0.001226633, z: 0.0011822907}
+  m_DirtyAABB: 0
+--- !u!1 &2909930762191494668
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6961613237804471489}
+  m_Layer: 0
+  m_Name: index_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6961613237804471489
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2909930762191494668}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.106761195, y: -0.47049862, z: 0.000018245846, w: 0.87591845}
+  m_LocalPosition: {x: 0.00014791187, y: 0.0011519569, z: 0.000089934096}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6668574397246592601}
+  m_Father: {fileID: 8469469290776545947}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2973014412694376869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2674201108341442512}
+  m_Layer: 0
+  m_Name: upperarm_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2674201108341442512
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2973014412694376869}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.01312217, y: -0.02405169, z: 0.3310979, w: 0.94319856}
+  m_LocalPosition: {x: -1.9790605e-11, y: 0.00165996, z: -1.3038516e-10}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8748112956975368665}
+  m_Father: {fileID: 3051309443278693626}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3005569535832103621
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1136360121860242035}
+  m_Layer: 0
+  m_Name: pinky_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1136360121860242035
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3005569535832103621}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.006279758, y: 0.0037737493, z: 0.009621405, w: 0.99992687}
+  m_LocalPosition: {x: -5.9604643e-10, y: 0.00017032727, z: 1.4901161e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4269926664162362132}
+  m_Father: {fileID: 5821344924666519087}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3064258831494314353
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8687739253276426027}
+  m_Layer: 0
+  m_Name: middle_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8687739253276426027
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3064258831494314353}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.045783933, y: -0.0049756006, z: 0.038089827, w: 0.9982125}
+  m_LocalPosition: {x: 2.9802322e-10, y: 0.00036860225, z: 0.000000001117587}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5289082858968763830}
+  m_Father: {fileID: 5131297903608675152}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3087668741802062974
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4123095201512823779}
+  m_Layer: 0
+  m_Name: Hip IK_target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4123095201512823779
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3087668741802062974}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4711015368239245717}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3104396262405928114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3051309443278693626}
+  m_Layer: 0
+  m_Name: clavicle_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3051309443278693626
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3104396262405928114}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0049917507, y: -0.04400219, z: 0.764789, w: 0.6427571}
+  m_LocalPosition: {x: -0.00022850296, y: 0.0025639683, z: 0.00092591805}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2674201108341442512}
+  m_Father: {fileID: 5986104100914816843}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3164205206043478610
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2523300434971526762}
+  m_Layer: 0
+  m_Name: head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2523300434971526762
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3164205206043478610}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.1955949, y: 0, z: -0, w: 0.9806848}
+  m_LocalPosition: {x: -0, y: 0.0010318425, z: 4.842877e-10}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 68161147633687569}
+  m_Father: {fileID: 2188576716467469478}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3376338844618107298
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6293534868797095896}
+  - component: {fileID: 3157453719418414604}
+  m_Layer: 0
+  m_Name: MeshSockets
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6293534868797095896
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3376338844618107298}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2498745504765516371}
+  - {fileID: 8601425833300080880}
+  - {fileID: 7627247127703959435}
+  - {fileID: 6400664125520123407}
+  - {fileID: 7320151553043424382}
+  - {fileID: 5288689046248452985}
+  - {fileID: 6943498800623017831}
+  - {fileID: 5459285771250164315}
+  - {fileID: 2139043125419085418}
+  - {fileID: 6697947064142767953}
+  - {fileID: 5065216409277844487}
+  - {fileID: 7493483055195106130}
+  m_Father: {fileID: 8090927086002730634}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3157453719418414604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3376338844618107298}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Effectors: []
+--- !u!1 &3453931308178962733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1450708989059031055}
+  m_Layer: 0
+  m_Name: ring_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1450708989059031055
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3453931308178962733}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.06621469, y: -0.010844178, z: -0.026695766, w: 0.9973893}
+  m_LocalPosition: {x: 2.9802322e-10, y: 0.00027139983, z: -7.45058e-10}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3084404794716346527}
+  m_Father: {fileID: 3965339155065461346}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3630814710036105206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2574208233736228566}
+  m_Layer: 0
+  m_Name: pinky_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2574208233736228566
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3630814710036105206}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.05129042, y: 0.28181514, z: -0.2981338, w: 0.9105305}
+  m_LocalPosition: {x: 0.00037495582, y: 0.00090687256, z: -0.00034174277}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7074783327219614238}
+  m_Father: {fileID: 8999583487048029766}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3657157381779635360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3501113679625403433}
+  m_Layer: 0
+  m_Name: clavicle_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3501113679625403433
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3657157381779635360}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0049917507, y: 0.04400219, z: -0.764789, w: 0.6427571}
+  m_LocalPosition: {x: 0.00022850296, y: 0.0025639683, z: 0.00092591805}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8840582609976541184}
+  m_Father: {fileID: 5986104100914816843}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3865862373237639743
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5131297903608675152}
+  m_Layer: 0
+  m_Name: middle_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5131297903608675152
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3865862373237639743}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.09815201, y: 0.40581596, z: -0.14945257, w: 0.89629436}
+  m_LocalPosition: {x: 0.000034184715, y: 0.0011137086, z: -0.00013092316}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8687739253276426027}
+  m_Father: {fileID: 8999583487048029766}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4078829578220559054
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6850267919126700859}
+  m_Layer: 0
+  m_Name: middle_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6850267919126700859
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4078829578220559054}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.045783933, y: 0.0049756006, z: -0.038089827, w: 0.9982125}
+  m_LocalPosition: {x: -2.9802322e-10, y: 0.00036860225, z: 0.000000001117587}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8107239698850677341}
+  m_Father: {fileID: 696785993163527895}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4162572889724830763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8492493929613164620}
+  m_Layer: 0
+  m_Name: calf_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8492493929613164620
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4162572889724830763}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.052983824, y: 0.23966551, z: -0.014489394, w: 0.9693004}
+  m_LocalPosition: {x: 2.7939677e-11, y: 0.0041764732, z: -1.862645e-10}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 487789334998833700}
+  m_Father: {fileID: 948697105358146688}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4282872549183373570
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7643123649930805853}
+  m_Layer: 0
+  m_Name: index_03_r_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7643123649930805853
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4282872549183373570}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00029122777, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2725790562469233658}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4295157698294401664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 517309775281467226}
+  m_Layer: 0
+  m_Name: lowerarm_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &517309775281467226
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4295157698294401664}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.39469355, y: 0.030597242, z: 0.025556607, w: 0.91794753}
+  m_LocalPosition: {x: -0.0000000011117663, y: 0.002515248, z: -4.6566126e-11}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8999583487048029766}
+  m_Father: {fileID: 8840582609976541184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4326704346831513776
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8840582609976541184}
+  m_Layer: 0
+  m_Name: upperarm_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8840582609976541184
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4326704346831513776}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.01312217, y: 0.02405169, z: -0.3310979, w: 0.94319856}
+  m_LocalPosition: {x: 1.9790605e-11, y: 0.00165996, z: -1.3038516e-10}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 517309775281467226}
+  m_Father: {fileID: 3501113679625403433}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4426654185269244293
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8469469290776545947}
+  m_Layer: 0
+  m_Name: hand_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8469469290776545947
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4426654185269244293}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.10511572, y: -0.39631137, z: 0.018570323, w: 0.9118899}
+  m_LocalPosition: {x: 5.3551047e-10, y: 0.0026666406, z: -1.4901161e-10}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6961613237804471489}
+  - {fileID: 696785993163527895}
+  - {fileID: 6355495790292457436}
+  - {fileID: 1978962930620663125}
+  - {fileID: 2366525845203493672}
+  m_Father: {fileID: 8748112956975368665}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4490220316173237122
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7270037277982463148}
+  m_Layer: 0
+  m_Name: ball_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7270037277982463148
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4490220316173237122}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0007129088, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5232637102226027305}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4509347618828637248
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3834684462413917049}
+  m_Layer: 0
+  m_Name: LH IK Target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3834684462413917049
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4509347618828637248}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244887, y: 0.05675955, z: 0.7039805, w: 0.7066255}
+  m_LocalPosition: {x: -0.867, y: 1.383, z: 0.007}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8936279123732570049}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4544558930224855572
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6668574397246592601}
+  m_Layer: 0
+  m_Name: index_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6668574397246592601
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4544558930224855572}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.106250115, y: 0.006514418, z: -0.006954575, w: 0.9942938}
+  m_LocalPosition: {x: 2.9802322e-10, y: 0.0002830904, z: 6.705522e-10}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5513135449600759724}
+  m_Father: {fileID: 6961613237804471489}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4619014373730402953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1978962930620663125}
+  m_Layer: 0
+  m_Name: ring_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1978962930620663125
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4619014373730402953}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.055121828, y: -0.38169524, z: 0.22911136, w: 0.893744}
+  m_LocalPosition: {x: -0.00018935192, y: 0.0010279795, z: -0.00026482396}
+  m_LocalScale: {x: 1.0000001, y: 1, z: 0.9999998}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 651937690382662841}
+  m_Father: {fileID: 8469469290776545947}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4685886197083489252
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 75155874047189440}
+  m_Layer: 0
+  m_Name: thumb_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &75155874047189440
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4685886197083489252}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.27830485, y: 0.70441926, z: 0.42949465, w: 0.49180713}
+  m_LocalPosition: {x: -0.00016217268, y: 0.00043533667, z: 0.00015525124}
+  m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8232954876648941758}
+  m_Father: {fileID: 8999583487048029766}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4715327411061827669
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 487789334998833700}
+  m_Layer: 0
+  m_Name: foot_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &487789334998833700
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4715327411061827669}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.5354672, y: -0.028092865, z: 0.021359533, w: 0.84381837}
+  m_LocalPosition: {x: 1.0739313e-10, y: 0.004351048, z: -2.3283064e-12}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1804531501257758633}
+  m_Father: {fileID: 8492493929613164620}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4970825024285933386
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5402661334123648563}
+  m_Layer: 0
+  m_Name: Left Leg IK_hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5402661334123648563
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4970825024285933386}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.16571158, y: 0.42413455, z: 0.7723244}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6608349870156286876}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5014174552102408167
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4711015368239245717}
+  - component: {fileID: 1862509620268000074}
+  - component: {fileID: 8388176782941620110}
+  m_Layer: 0
+  m_Name: Hip Constraint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4711015368239245717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5014174552102408167}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4123095201512823779}
+  m_Father: {fileID: 179518177863995514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1862509620268000074
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5014174552102408167}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Effectors: []
+--- !u!114 &8388176782941620110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5014174552102408167}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_ConstrainedObject: {fileID: 1836783262349754282}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 4123095201512823779}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 0
+    m_MaintainRotationOffset: 1
+--- !u!1 &5030923133547564143
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1063240471916693759}
+  - component: {fileID: 2421088218824497152}
+  m_Layer: 0
+  m_Name: Human.teeth_base_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1063240471916693759
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5030923133547564143}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2989011612062175184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &2421088218824497152
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5030923133547564143}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 43d44152acfc6c64f95a318147ab1260, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 1537935510817236208, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
+  m_Bones:
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 1693096230734883884}
+  m_AABB:
+    m_Center: {x: 0.0000000015716068, y: -0.0010988635, z: 0.015431106}
+    m_Extent: {x: 0.00030522048, y: 0.00039164524, z: 0.00025921548}
+  m_DirtyAABB: 0
+--- !u!1 &5094083304417318102
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 220231546587466067}
+  m_Layer: 0
+  m_Name: foot_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &220231546587466067
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5094083304417318102}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.5354672, y: 0.028092865, z: -0.021359533, w: 0.84381837}
+  m_LocalPosition: {x: -1.0739313e-10, y: 0.004351048, z: -2.3283064e-12}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5232637102226027305}
+  m_Father: {fileID: 971455242581857}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5306427451682083861
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3965339155065461346}
+  m_Layer: 0
+  m_Name: ring_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3965339155065461346
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5306427451682083861}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.055358116, y: -0.0014519498, z: 0.04723631, w: 0.99734753}
+  m_LocalPosition: {x: -0, y: 0.0003247219, z: 9.685754e-10}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1450708989059031055}
+  m_Father: {fileID: 8267148477398227571}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5407002161996261317
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8769901375918295783}
+  - component: {fileID: 2693704958468889925}
+  m_Layer: 0
+  m_Name: Human.pants.002_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8769901375918295783
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5407002161996261317}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2989011612062175184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &2693704958468889925
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5407002161996261317}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 30228ca1642fec04db8454be525b9f03, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 3018101524230511947, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
+  m_Bones:
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 1693096230734883884}
+  m_AABB:
+    m_Center: {x: 0.000005827984, y: -0.0001759138, z: 0.005519245}
+    m_Extent: {x: 0.0029234507, y: 0.002007253, z: 0.004964876}
+  m_DirtyAABB: 0
+--- !u!1 &5740284345174632213
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3613427011463542475}
+  m_Layer: 0
+  m_Name: middle_03_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3613427011463542475
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5740284345174632213}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00029352933, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8107239698850677341}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5793294368936637184
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8936279123732570049}
+  - component: {fileID: 4656443947287584057}
+  m_Layer: 0
+  m_Name: Left Arm IK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8936279123732570049
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5793294368936637184}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3834684462413917049}
+  - {fileID: 5198755756533146958}
+  m_Father: {fileID: 179518177863995514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4656443947287584057
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5793294368936637184}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_Root: {fileID: 2674201108341442512}
+    m_Mid: {fileID: 8748112956975368665}
+    m_Tip: {fileID: 8469469290776545947}
+    m_Target: {fileID: 3834684462413917049}
+    m_Hint: {fileID: 5198755756533146958}
+    m_TargetPositionWeight: 1
+    m_TargetRotationWeight: 1
+    m_HintWeight: 1
+    m_MaintainTargetPositionOffset: 0
+    m_MaintainTargetRotationOffset: 0
+--- !u!1 &5851008200894963740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1889593047932587842}
+  - component: {fileID: 6792015281752384317}
+  m_Layer: 0
+  m_Name: Human.tongue01.001_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1889593047932587842
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5851008200894963740}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2989011612062175184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6792015281752384317
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5851008200894963740}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6dfcb1430d5ed9d42b5476de99a5972e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 8229990212890976534, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
+  m_Bones:
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 1693096230734883884}
+  m_AABB:
+    m_Center: {x: 0, y: -0.0010296531, z: 0.015455364}
+    m_Extent: {x: 0.0002215562, y: 0.00035439502, z: 0.00014522765}
+  m_DirtyAABB: 0
+--- !u!1 &5858980007301502220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2544324816884631017}
+  - component: {fileID: 7800409564849462682}
+  m_Layer: 0
+  m_Name: Human.eyelashes01_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2544324816884631017
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5858980007301502220}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2989011612062175184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &7800409564849462682
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5858980007301502220}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 422b5d3233594cb4b8199078557082ba, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -5903601820808268019, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
+  m_Bones:
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 1693096230734883884}
+  m_AABB:
+    m_Center: {x: 0, y: -0.0014064594, z: 0.016175518}
+    m_Extent: {x: 0.00048225332, y: 0.00007532316, z: 0.00007107109}
+  m_DirtyAABB: 0
+--- !u!1 &5928083739207313202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5065216409277844487}
+  - component: {fileID: 2705146188565098132}
+  - component: {fileID: 6782514595774801569}
+  m_Layer: 0
+  m_Name: HipsFrontRightSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5065216409277844487
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5928083739207313202}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
+  m_LocalPosition: {x: 0.081, y: 0.985, z: 0.107}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6293534868797095896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2705146188565098132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5928083739207313202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 9
+--- !u!114 &6782514595774801569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5928083739207313202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 5065216409277844487}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 1836783262349754282}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &6329498441956153300
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5986104100914816843}
+  m_Layer: 0
+  m_Name: spine_03
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5986104100914816843
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6329498441956153300}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.011703165, y: 0, z: -0, w: 0.9999315}
+  m_LocalPosition: {x: -0, y: 0.0006111533, z: -9.313225e-11}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3051309443278693626}
+  - {fileID: 3501113679625403433}
+  - {fileID: 2188576716467469478}
+  m_Father: {fileID: 7552695108017669976}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6487502788049132368
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2725790562469233658}
+  m_Layer: 0
+  m_Name: index_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2725790562469233658
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6487502788049132368}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.06060502, y: 0.00016188687, z: 0.016979786, w: 0.9980174}
+  m_LocalPosition: {x: 2.9802322e-10, y: 0.0002536689, z: -2.9802322e-10}
+  m_LocalScale: {x: 1, y: 0.9999998, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7643123649930805853}
+  m_Father: {fileID: 7765029833600690865}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6512546445236618737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5288689046248452985}
+  - component: {fileID: 7647781734411894799}
+  - component: {fileID: 6865461852032011527}
+  m_Layer: 0
+  m_Name: LeftUpperArmSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5288689046248452985
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6512546445236618737}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
+  m_LocalPosition: {x: -0.1861217, y: 1.3786533, z: 0.01777029}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6293534868797095896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7647781734411894799
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6512546445236618737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 4
+--- !u!114 &6865461852032011527
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6512546445236618737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 5288689046248452985}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 2674201108341442512}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &6524609164165005715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2366525845203493672}
+  m_Layer: 0
+  m_Name: thumb_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2366525845203493672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6524609164165005715}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.27830485, y: 0.70441926, z: 0.42949465, w: -0.49180713}
+  m_LocalPosition: {x: 0.00016217268, y: 0.00043533667, z: 0.00015525124}
+  m_LocalScale: {x: 0.99999994, y: 0.9999998, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3456447928604432422}
+  m_Father: {fileID: 8469469290776545947}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6526983897078211203
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 696785993163527895}
+  m_Layer: 0
+  m_Name: middle_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &696785993163527895
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6526983897078211203}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.09815201, y: -0.40581596, z: 0.14945257, w: 0.89629436}
+  m_LocalPosition: {x: -0.000034184715, y: 0.0011137086, z: -0.00013092316}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6850267919126700859}
+  m_Father: {fileID: 8469469290776545947}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6695127571756495273
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8280908286299490160}
+  m_Layer: 0
+  m_Name: Left Leg IK_target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8280908286299490160
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6695127571756495273}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.8550024, y: -0.013999376, z: 0.02312521, w: 0.517919}
+  m_LocalPosition: {x: -0.089982, y: 0.10216425, z: -0.050898075}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6608349870156286876}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6775261064374973579
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7074783327219614238}
+  m_Layer: 0
+  m_Name: pinky_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7074783327219614238
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6775261064374973579}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.08232218, y: -0.005569877, z: 0.022216821, w: 0.99634254}
+  m_LocalPosition: {x: -0, y: 0.00023309975, z: 8.5681673e-10}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7571026651442612078}
+  m_Father: {fileID: 2574208233736228566}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6813479042301311219
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1693096230734883884}
+  m_Layer: 0
+  m_Name: Root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1693096230734883884
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6813479042301311219}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: -6.1001626e-10, z: 0.0000030586123}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1836783262349754282}
+  m_Father: {fileID: 3398274022961908452}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6992671568406009882
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4981113335983373325}
+  m_Layer: 0
+  m_Name: pinky_03_r_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4981113335983373325
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6992671568406009882}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00021657793, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7571026651442612078}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7081559132267044661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5217812072671155504}
+  m_Layer: 0
+  m_Name: Right Leg IK_hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5217812072671155504
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7081559132267044661}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.16571209, y: 0.42413566, z: 0.77232444}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 834849821424450799}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7137911830143959430
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6355495790292457436}
   m_Layer: 0
   m_Name: pinky_01_l
   m_TagString: Untagged
@@ -5635,23 +4407,1353 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5492228165484452729
+--- !u!4 &6355495790292457436
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9195597944749937307}
+  m_GameObject: {fileID: 7137911830143959430}
   serializedVersion: 2
   m_LocalRotation: {x: 0.05129042, y: -0.28181514, z: 0.2981338, w: 0.9105305}
   m_LocalPosition: {x: -0.00037495582, y: 0.00090687256, z: -0.00034174277}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 738660233367961331}
-  m_Father: {fileID: 2153120414674204035}
+  - {fileID: 5821344924666519087}
+  m_Father: {fileID: 8469469290776545947}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &5071057364203067724
+--- !u!1 &7150017327441053901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 652537406475221492}
+  m_Layer: 0
+  m_Name: spine_01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &652537406475221492
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7150017327441053901}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.23930582, y: 0, z: -0, w: 0.9709442}
+  m_LocalPosition: {x: -0, y: 0.00092233164, z: 1.6763806e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7552695108017669976}
+  m_Father: {fileID: 1836783262349754282}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7191290337406568566
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7274251621029207316}
+  m_Layer: 0
+  m_Name: thigh_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7274251621029207316
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7191290337406568566}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.96511555, y: -0.08017611, z: 0.21919036, w: -0.118656375}
+  m_LocalPosition: {x: -0.0010853513, y: -0.000014180334, z: -0.0001171541}
+  m_LocalScale: {x: 1.0000002, y: 1.0000001, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 971455242581857}
+  m_Father: {fileID: 1836783262349754282}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7381618551513384368
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6244180546485434274}
+  m_Layer: 0
+  m_Name: ring_03_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6244180546485434274
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7381618551513384368}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00029037573, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8256594702401535101}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7417652089220938684
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4441622350715404381}
+  - component: {fileID: 2925520044185516302}
+  m_Layer: 0
+  m_Name: Human.low-poly.001_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4441622350715404381
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7417652089220938684}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2989011612062175184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &2925520044185516302
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7417652089220938684}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ff26a6916d844834f9f0d93ebec56b5e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -9063650396101244781, guid: 10756e802a0e4e04ebc9e4276377045c, type: 3}
+  m_Bones:
+  - {fileID: 1693096230734883884}
+  - {fileID: 1836783262349754282}
+  - {fileID: 652537406475221492}
+  - {fileID: 7552695108017669976}
+  - {fileID: 5986104100914816843}
+  - {fileID: 3051309443278693626}
+  - {fileID: 2674201108341442512}
+  - {fileID: 8748112956975368665}
+  - {fileID: 8469469290776545947}
+  - {fileID: 6961613237804471489}
+  - {fileID: 6668574397246592601}
+  - {fileID: 5513135449600759724}
+  - {fileID: 696785993163527895}
+  - {fileID: 6850267919126700859}
+  - {fileID: 8107239698850677341}
+  - {fileID: 6355495790292457436}
+  - {fileID: 5821344924666519087}
+  - {fileID: 1136360121860242035}
+  - {fileID: 1978962930620663125}
+  - {fileID: 651937690382662841}
+  - {fileID: 8256594702401535101}
+  - {fileID: 2366525845203493672}
+  - {fileID: 3456447928604432422}
+  - {fileID: 1652572097934650434}
+  - {fileID: 3501113679625403433}
+  - {fileID: 8840582609976541184}
+  - {fileID: 517309775281467226}
+  - {fileID: 8999583487048029766}
+  - {fileID: 6627986633412452774}
+  - {fileID: 7765029833600690865}
+  - {fileID: 2725790562469233658}
+  - {fileID: 5131297903608675152}
+  - {fileID: 8687739253276426027}
+  - {fileID: 5289082858968763830}
+  - {fileID: 2574208233736228566}
+  - {fileID: 7074783327219614238}
+  - {fileID: 7571026651442612078}
+  - {fileID: 8267148477398227571}
+  - {fileID: 3965339155065461346}
+  - {fileID: 1450708989059031055}
+  - {fileID: 75155874047189440}
+  - {fileID: 8232954876648941758}
+  - {fileID: 5189901391672644983}
+  - {fileID: 2188576716467469478}
+  - {fileID: 2523300434971526762}
+  - {fileID: 7274251621029207316}
+  - {fileID: 971455242581857}
+  - {fileID: 220231546587466067}
+  - {fileID: 5232637102226027305}
+  - {fileID: 948697105358146688}
+  - {fileID: 8492493929613164620}
+  - {fileID: 487789334998833700}
+  - {fileID: 1804531501257758633}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 1693096230734883884}
+  m_AABB:
+    m_Center: {x: 0, y: -0.001302408, z: 0.016203536}
+    m_Extent: {x: 0.00044132542, y: 0.0001255651, z: 0.00014419295}
+  m_DirtyAABB: 0
+--- !u!1 &7427396624770524530
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3223582963681919740}
+  m_Layer: 0
+  m_Name: middle_03_r_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3223582963681919740
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7427396624770524530}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00029352933, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5289082858968763830}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7427913906714808256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8601425833300080880}
+  - component: {fileID: 6260799704251811003}
+  - component: {fileID: 7615324823115975657}
+  m_Layer: 0
+  m_Name: LeftHandSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8601425833300080880
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7427913906714808256}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
+  m_LocalPosition: {x: -0.5097, y: 1.0025, z: 0.2507}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6293534868797095896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6260799704251811003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7427913906714808256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 1
+--- !u!114 &7615324823115975657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7427913906714808256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 8601425833300080880}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 8469469290776545947}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &7622449473971750687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6608349870156286876}
+  - component: {fileID: 7549151837240053857}
+  - component: {fileID: 4176365786343007431}
+  m_Layer: 0
+  m_Name: Left Leg IK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6608349870156286876
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7622449473971750687}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8280908286299490160}
+  - {fileID: 5402661334123648563}
+  m_Father: {fileID: 179518177863995514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7549151837240053857
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7622449473971750687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Effectors:
+  - m_Transform: {fileID: 8280908286299490160}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 5402661334123648563}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 0}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 5402661334123648563}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 8280908286299490160}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 5402661334123648563}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!114 &4176365786343007431
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7622449473971750687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_Root: {fileID: 7274251621029207316}
+    m_Mid: {fileID: 971455242581857}
+    m_Tip: {fileID: 220231546587466067}
+    m_Target: {fileID: 8280908286299490160}
+    m_Hint: {fileID: 5402661334123648563}
+    m_TargetPositionWeight: 1
+    m_TargetRotationWeight: 1
+    m_HintWeight: 0
+    m_MaintainTargetPositionOffset: 1
+    m_MaintainTargetRotationOffset: 1
+--- !u!1 &7744561349084487600
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8748112956975368665}
+  m_Layer: 0
+  m_Name: lowerarm_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8748112956975368665
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7744561349084487600}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.39469355, y: -0.030597242, z: -0.025556607, w: 0.91794753}
+  m_LocalPosition: {x: 0.0000000011117663, y: 0.002515248, z: -4.6566126e-11}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8469469290776545947}
+  m_Father: {fileID: 2674201108341442512}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7752106019608872525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3151137100407803015}
+  m_Layer: 0
+  m_Name: RH IK Target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3151137100407803015
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7752106019608872525}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244947, y: -0.056759432, z: -0.70398045, w: 0.7066256}
+  m_LocalPosition: {x: 0.676, y: 1.385, z: 0.081}
+  m_LocalScale: {x: 1.0000005, y: 1.0000004, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2540796198656271744}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7795490996429205678
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 948697105358146688}
+  m_Layer: 0
+  m_Name: thigh_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &948697105358146688
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795490996429205678}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.96511555, y: 0.08017611, z: -0.21919036, w: -0.118656375}
+  m_LocalPosition: {x: 0.0010853513, y: -0.000014180334, z: -0.0001171541}
+  m_LocalScale: {x: 1.0000002, y: 1.0000001, z: 1.0000017}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8492493929613164620}
+  m_Father: {fileID: 1836783262349754282}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7830203871751401856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2188576716467469478}
+  m_Layer: 0
+  m_Name: neck_01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2188576716467469478
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7830203871751401856}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.25270265, y: 0, z: -0, w: 0.967544}
+  m_LocalPosition: {x: -0, y: 0.003317179, z: 0.0009271641}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2523300434971526762}
+  m_Father: {fileID: 5986104100914816843}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7952802305209066115
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5459285771250164315}
+  - component: {fileID: 2038441769142380045}
+  - component: {fileID: 8693562428336582274}
+  m_Layer: 0
+  m_Name: LeftBackSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5459285771250164315
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7952802305209066115}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.72605973, y: 0.000000014901156, z: -0, w: 0.68763167}
+  m_LocalPosition: {x: -0.095, y: 1.393, z: -0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6293534868797095896}
+  m_LocalEulerAnglesHint: {x: 93.11401, y: 0, z: 0}
+--- !u!114 &2038441769142380045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7952802305209066115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 7
+--- !u!114 &8693562428336582274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7952802305209066115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 5459285771250164315}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 7552695108017669976}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &7980665154081680582
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6697947064142767953}
+  - component: {fileID: 8978810733756309955}
+  - component: {fileID: 2353297857917493125}
+  m_Layer: 0
+  m_Name: HipsBackRightSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6697947064142767953
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7980665154081680582}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
+  m_LocalPosition: {x: 0.078, y: 1.034, z: -0.076}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6293534868797095896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8978810733756309955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7980665154081680582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 11
+--- !u!114 &2353297857917493125
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7980665154081680582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 6697947064142767953}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 1836783262349754282}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &8289185403960549874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7627247127703959435}
+  - component: {fileID: 3966216173582403578}
+  - component: {fileID: 3662788265620040379}
+  m_Layer: 0
+  m_Name: RightLowerArmSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7627247127703959435
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8289185403960549874}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.050784193, y: -0.06303089, z: -0.713447, w: 0.6960184}
+  m_LocalPosition: {x: 0.35143352, y: 1.1890961, z: 0.015590668}
+  m_LocalScale: {x: 0.9999998, y: 0.99999964, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6293534868797095896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3966216173582403578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8289185403960549874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 2
+--- !u!114 &3662788265620040379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8289185403960549874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 7627247127703959435}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 517309775281467226}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &8413329385915247396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3084404794716346527}
+  m_Layer: 0
+  m_Name: ring_03_r_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3084404794716346527
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8413329385915247396}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00029037573, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1450708989059031055}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8564017596351600328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5232637102226027305}
+  m_Layer: 0
+  m_Name: ball_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5232637102226027305
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8564017596351600328}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.25208107, y: 0.24984322, z: -0.10381857, w: 0.9291153}
+  m_LocalPosition: {x: -2.0663719e-11, y: 0.0014053999, z: 7.4505804e-11}
+  m_LocalScale: {x: 0.9999999, y: 0.9999999, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7270037277982463148}
+  m_Father: {fileID: 220231546587466067}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8570038113866954489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5189901391672644983}
+  m_Layer: 0
+  m_Name: thumb_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5189901391672644983
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8570038113866954489}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.14160986, y: 0.023658447, z: -0.040257353, w: 0.9888207}
+  m_LocalPosition: {x: -2.6077032e-10, y: 0.00039843097, z: 2.2351741e-10}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 310635262587005811}
+  m_Father: {fileID: 8232954876648941758}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8578524292639495558
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 651937690382662841}
+  m_Layer: 0
+  m_Name: ring_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &651937690382662841
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8578524292639495558}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.055358116, y: 0.0014519498, z: -0.04723631, w: 0.99734753}
+  m_LocalPosition: {x: -0, y: 0.0003247219, z: 9.685754e-10}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8256594702401535101}
+  m_Father: {fileID: 1978962930620663125}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8592387126021022171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7552695108017669976}
+  m_Layer: 0
+  m_Name: spine_02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7552695108017669976
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8592387126021022171}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.13355094, y: 0, z: -0, w: 0.99104196}
+  m_LocalPosition: {x: -0, y: 0.0007041444, z: 3.7252902e-11}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5986104100914816843}
+  m_Father: {fileID: 652537406475221492}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8694393773781782315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1652572097934650434}
+  m_Layer: 0
+  m_Name: thumb_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1652572097934650434
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8694393773781782315}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.14160986, y: -0.023658447, z: 0.040257353, w: 0.9888207}
+  m_LocalPosition: {x: 2.6077032e-10, y: 0.00039843097, z: 2.2351741e-10}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7439491387534474585}
+  m_Father: {fileID: 3456447928604432422}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8729804557283275904
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3398274022961908452}
+  m_Layer: 0
+  m_Name: Human.001.rig_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3398274022961908452
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8729804557283275904}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071067}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 100, y: 100, z: 100}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1693096230734883884}
+  m_Father: {fileID: 2989011612062175184}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8763747119699435499
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3456447928604432422}
+  m_Layer: 0
+  m_Name: thumb_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3456447928604432422
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8763747119699435499}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.051922955, y: 0.02436226, z: 0.18687437, w: 0.9807082}
+  m_LocalPosition: {x: 1.3038516e-10, y: 0.00033529996, z: -5.587935e-10}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1652572097934650434}
+  m_Father: {fileID: 2366525845203493672}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8809840511027099019
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8232954876648941758}
+  m_Layer: 0
+  m_Name: thumb_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8232954876648941758
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8809840511027099019}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.051922955, y: -0.02436226, z: -0.18687437, w: 0.9807082}
+  m_LocalPosition: {x: -1.3038516e-10, y: 0.00033529996, z: -5.587935e-10}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5189901391672644983}
+  m_Father: {fileID: 75155874047189440}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8872285878341389464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7215238448763726459}
+  m_Layer: 0
+  m_Name: index_03_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7215238448763726459
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8872285878341389464}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00029122777, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5513135449600759724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8874195099609494002
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 834849821424450799}
+  - component: {fileID: 495819561279570828}
+  - component: {fileID: 3650180943910483076}
+  m_Layer: 0
+  m_Name: Right Leg IK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &834849821424450799
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8874195099609494002}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7183150599398145676}
+  - {fileID: 5217812072671155504}
+  m_Father: {fileID: 179518177863995514}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &495819561279570828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8874195099609494002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Effectors:
+  - m_Transform: {fileID: 7183150599398145676}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 5217812072671155504}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 7183150599398145676}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 5217812072671155504}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!114 &3650180943910483076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8874195099609494002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_Root: {fileID: 948697105358146688}
+    m_Mid: {fileID: 8492493929613164620}
+    m_Tip: {fileID: 487789334998833700}
+    m_Target: {fileID: 7183150599398145676}
+    m_Hint: {fileID: 5217812072671155504}
+    m_TargetPositionWeight: 1
+    m_TargetRotationWeight: 1
+    m_HintWeight: 0
+    m_MaintainTargetPositionOffset: 1
+    m_MaintainTargetRotationOffset: 1
+--- !u!1001 &3382664311758825531
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -5665,15 +5767,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -4.6508493
+      value: 2.7542436
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.000000015721866
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.83839893
+      value: 3.4413314
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       propertyPath: m_LocalRotation.w
@@ -5736,7 +5838,7 @@ PrefabInstance:
       value: AgentBasedOnhuman001
       objectReference: {fileID: 0}
     - target: {fileID: 2021133116110439406, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
-      propertyPath: m_Materials.Array.data[0]
+      propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: fb4b7816a049cf244af9684f69d89b92, type: 2}
     - target: {fileID: 5866666021909216657, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
@@ -5814,95 +5916,90 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 45686693253767573}
+      addedObject: {fileID: 8090927086002730634}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 8744288214721473780}
+      addedObject: {fileID: 3398274022961908452}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 599570897989283192}
+      addedObject: {fileID: 63478134055451994}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 3683340180554708531}
+      addedObject: {fileID: 5487360084104021522}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1791206551703019591}
+      addedObject: {fileID: 566189503457441254}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 8737835994182091433}
+      addedObject: {fileID: 2544324816884631017}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 4736802005887745609}
+      addedObject: {fileID: 4441622350715404381}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 5550836990480135093}
+      addedObject: {fileID: 8769901375918295783}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 2016040959044072176}
+      addedObject: {fileID: 1409953973312936873}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 6820217535245325422}
+      addedObject: {fileID: 1063240471916693759}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7839319948903931383}
+      addedObject: {fileID: 1889593047932587842}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 4350913981428511573}
+      addedObject: {fileID: 5342031102609170254}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 3000973314931460519}
+      addedObject: {fileID: 4405029950365877461}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 3017375031970236673}
+      addedObject: {fileID: 4164393798510750769}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 6039966719846468055}
+      addedObject: {fileID: 4250017656702817900}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 5826933027300415404}
+      addedObject: {fileID: 7132606487843782789}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 542117837496902555}
+      addedObject: {fileID: 2039629895304201926}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 3559126510004136387}
+      addedObject: {fileID: 6088741013383047379}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 233930394031969971}
+      addedObject: {fileID: 6731602536767844426}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 2591100199878245547}
+      addedObject: {fileID: 6705975684953135322}
   m_SourcePrefab: {fileID: 100100000, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
---- !u!4 &4749814036626849447 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
-  m_PrefabInstance: {fileID: 5071057364203067724}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &5377696115611067421 stripped
+--- !u!1 &2463691737953703274 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
-  m_PrefabInstance: {fileID: 5071057364203067724}
+  m_PrefabInstance: {fileID: 3382664311758825531}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &3000973314931460519
+--- !u!114 &4405029950365877461
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377696115611067421}
+  m_GameObject: {fileID: 2463691737953703274}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2eb11c02fcaa7fa40861161120bf3b98, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &3017375031970236673
+--- !u!114 &4164393798510750769
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377696115611067421}
+  m_GameObject: {fileID: 2463691737953703274}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8d1f53ec0650eb049b6fa464e3c03437, type: 3}
@@ -5912,13 +6009,13 @@ MonoBehaviour:
   angularSpeed: Turn
   rotationDirection: RotationDirection
   isRotating: IsRotating
---- !u!195 &6039966719846468055
+--- !u!195 &4250017656702817900
 NavMeshAgent:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377696115611067421}
+  m_GameObject: {fileID: 2463691737953703274}
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.33
@@ -5934,45 +6031,49 @@ NavMeshAgent:
   m_BaseOffset: -0.06
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
---- !u!114 &5826933027300415404
+--- !u!114 &7132606487843782789
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377696115611067421}
+  m_GameObject: {fileID: 2463691737953703274}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 96bc75292d584fe4598ab674a7c7ddfd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <TwoBoneIKConstraintRightArm>k__BackingField: {fileID: 1377062839725788164}
-  <TwoBoneIKConstraintLeftArm>k__BackingField: {fileID: 6967384933256025995}
---- !u!114 &542117837496902555
+  <TwoBoneIKConstraintRightArm>k__BackingField: {fileID: 8520051597309659016}
+  <TwoBoneIKConstraintLeftArm>k__BackingField: {fileID: 4656443947287584057}
+  <MultiParentConstraintHip>k__BackingField: {fileID: 8388176782941620110}
+  <TwoBoneIKConstraintLeftLeg>k__BackingField: {fileID: 4176365786343007431}
+  <TwoBoneIKConstraintRightLeg>k__BackingField: {fileID: 3650180943910483076}
+  <MultiAimConstraintSpine>k__BackingField: {fileID: 7663371753980581929}
+--- !u!114 &2039629895304201926
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377696115611067421}
+  m_GameObject: {fileID: 2463691737953703274}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fff0960ef4ea6e04eac66b4a7fd2189d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_RigLayers:
-  - m_Rig: {fileID: 764515105324343442}
+  - m_Rig: {fileID: 3157453719418414604}
     m_Active: 1
-  - m_Rig: {fileID: 5438971196406090817}
+  - m_Rig: {fileID: 4265270270235904556}
     m_Active: 1
   m_Effectors: []
---- !u!114 &3559126510004136387
+--- !u!114 &6088741013383047379
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377696115611067421}
+  m_GameObject: {fileID: 2463691737953703274}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 88c1ed013dd3e92439b19c5c699179c6, type: 3}
@@ -5995,29 +6096,30 @@ MonoBehaviour:
   occlusionLayers:
     serializedVersion: 2
     m_Bits: 1
---- !u!114 &233930394031969971
+--- !u!114 &6731602536767844426
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377696115611067421}
+  m_GameObject: {fileID: 2463691737953703274}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: afa2f315da5127e47a996e328f4ffff3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!82 &2591100199878245547
+--- !u!82 &6705975684953135322
 AudioSource:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5377696115611067421}
+  m_GameObject: {fileID: 2463691737953703274}
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
@@ -6103,3 +6205,8 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!4 &2989011612062175184 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
+  m_PrefabInstance: {fileID: 3382664311758825531}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Virtual Agents Framework/Runtime/Prefabs/AgentBasedOnhuman003.prefab
+++ b/Assets/Virtual Agents Framework/Runtime/Prefabs/AgentBasedOnhuman003.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &20081654495426084
+--- !u!1 &44940314376311589
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,31 +8,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2020823335098461711}
+  - component: {fileID: 4888662384396461074}
   m_Layer: 0
-  m_Name: middle_03_r
+  m_Name: Left Leg IK_hint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2020823335098461711
+--- !u!4 &4888662384396461074
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 20081654495426084}
+  m_GameObject: {fileID: 44940314376311589}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.06620053, y: 0.008922866, z: -0.0063932124, w: 0.997746}
-  m_LocalPosition: {x: -0, y: 0.00025188894, z: 7.4505804e-11}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.16571158, y: 0.42413455, z: 0.7723244}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4105303436502670335}
-  m_Father: {fileID: 2748903378610732510}
+  m_Children: []
+  m_Father: {fileID: 8477797510293541801}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &141904991030646694
+--- !u!1 &123626702815337160
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -40,169 +39,94 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 966263828761334213}
+  - component: {fileID: 8219266566289854322}
   m_Layer: 0
-  m_Name: thumb_03_l
+  m_Name: Root
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &966263828761334213
+--- !u!4 &8219266566289854322
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 141904991030646694}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.139098, y: 0.04476655, z: 0.024881518, w: 0.9889533}
-  m_LocalPosition: {x: -2.2351741e-10, y: 0.00032632975, z: -4.4703483e-10}
-  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4163691610125674352}
-  m_Father: {fileID: 5081651697852610259}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &207155513623391640
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1075986095039001427}
-  - component: {fileID: 8042046346743857933}
-  m_Layer: 0
-  m_Name: Human.eyebrow008.001_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1075986095039001427
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 207155513623391640}
+  m_GameObject: {fileID: 123626702815337160}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: -0, y: -6.1001626e-10, z: -0.0000010177492}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 342574450868786768}
+  m_Father: {fileID: 6529172150956068362}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &142302117689990546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9046239492538980212}
+  m_Layer: 0
+  m_Name: thigh_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9046239492538980212
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 142302117689990546}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.9475263, y: 0.10418324, z: -0.20727295, w: -0.21994945}
+  m_LocalPosition: {x: 0.0009458223, y: -0.00006587047, z: -0.00011003237}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7489914242463965228}
+  m_Father: {fileID: 342574450868786768}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &170380160069531094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4499880974459164217}
+  m_Layer: 0
+  m_Name: index_03_r_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4499880974459164217
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 170380160069531094}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00024752432, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6556864370830939371}
+  m_Father: {fileID: 4335524568324716511}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &8042046346743857933
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 207155513623391640}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 34a246b576ca09a4aa8e0f0f9bf907c6, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -4963569351153215188, guid: 202215a518327c145ad063e646529afb, type: 3}
-  m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
-  m_AABB:
-    m_Center: {x: 0, y: -0.0012217993, z: 0.0149888415}
-    m_Extent: {x: 0.0005298177, y: 0.00013988616, z: 0.000075032}
-  m_DirtyAABB: 0
---- !u!1 &257641795431781698
+--- !u!1 &254198573792288178
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -210,72 +134,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4357164833074477120}
-  m_Layer: 0
-  m_Name: foot_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4357164833074477120
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 257641795431781698}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.53481025, y: 0.026531031, z: -0.020641703, w: 0.84430325}
-  m_LocalPosition: {x: -1.132139e-10, y: 0.0037914454, z: 3.259629e-11}
-  m_LocalScale: {x: 1, y: 1, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1619068815029867637}
-  m_Father: {fileID: 892847256484991937}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &310731576604237828
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2748903378610732510}
-  m_Layer: 0
-  m_Name: middle_02_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2748903378610732510
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 310731576604237828}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0486796, y: 0.0050305324, z: 0.035270266, w: 0.99817884}
-  m_LocalPosition: {x: -0, y: 0.00030750938, z: 2.9802322e-10}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2020823335098461711}
-  m_Father: {fileID: 2585025911604653489}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &404635985948141702
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3371423488310119115}
-  - component: {fileID: 4117478906625385914}
+  - component: {fileID: 1413476190920327439}
+  - component: {fileID: 7582124529681694670}
   m_Layer: 0
   m_Name: Human.teeth_base.002_export_copy
   m_TagString: Untagged
@@ -283,28 +143,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3371423488310119115
+--- !u!4 &1413476190920327439
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 404635985948141702}
+  m_GameObject: {fileID: 254198573792288178}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6556864370830939371}
+  m_Father: {fileID: 8229891078867211912}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &4117478906625385914
+--- !u!137 &7582124529681694670
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 404635985948141702}
+  m_GameObject: {fileID: 254198573792288178}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -315,6 +175,11 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -336,75 +201,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: -272018847992369958, guid: 202215a518327c145ad063e646529afb, type: 3}
   m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
+  m_RootBone: {fileID: 8219266566289854322}
   m_AABB:
     m_Center: {x: 0.0000000015133992, y: -0.0009787064, z: 0.014210818}
     m_Extent: {x: 0.00028988457, y: 0.00036612863, z: 0.00024080835}
   m_DirtyAABB: 0
---- !u!1 &414583925209103845
+--- !u!1 &289738657147300482
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -412,128 +279,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1118308365334064511}
-  - component: {fileID: 250133716720627989}
-  - component: {fileID: 7234407960002686995}
+  - component: {fileID: 1300560289145079763}
   m_Layer: 0
-  m_Name: RightBackSocket
+  m_Name: pinky_03_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1118308365334064511
+--- !u!4 &1300560289145079763
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 414583925209103845}
+  m_GameObject: {fileID: 289738657147300482}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.72605973, y: 0.000000014901156, z: -0, w: 0.68763167}
-  m_LocalPosition: {x: 0.099, y: 1.393, z: -0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
-  m_LocalEulerAnglesHint: {x: 93.11401, y: 0, z: 0}
---- !u!114 &250133716720627989
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 414583925209103845}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 6
---- !u!114 &7234407960002686995
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 414583925209103845}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 1118308365334064511}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &642177359787782421
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7861684926067814557}
-  m_Layer: 0
-  m_Name: index_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7861684926067814557
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642177359787782421}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.063697554, y: -0.0026903162, z: -0.021007935, w: 0.9977445}
-  m_LocalPosition: {x: -0, y: 0.0002082094, z: -1.4901161e-10}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_LocalRotation: {x: -0.011243035, y: -0.0031115646, z: 0.013404051, w: 0.9998421}
+  m_LocalPosition: {x: -0, y: 0.00014155026, z: 3.7252902e-11}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7311315713009681036}
-  m_Father: {fileID: 8647527434660935863}
+  - {fileID: 6831215402655570018}
+  m_Father: {fileID: 4655419516182394031}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &684486003119505187
+--- !u!1 &583566657351229366
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -541,448 +311,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4219102615782077759}
+  - component: {fileID: 6933541327734477180}
   m_Layer: 0
-  m_Name: Human.003.rig_export_copy
+  m_Name: index_03_l_end
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4219102615782077759
+--- !u!4 &6933541327734477180
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 684486003119505187}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 100, y: 100, z: 100}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8592307629047571670}
-  m_Father: {fileID: 6556864370830939371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &786331476243741307
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2311160514431422238}
-  m_Layer: 0
-  m_Name: ball_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2311160514431422238
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 786331476243741307}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.24330804, y: -0.39314923, z: 0.07650533, w: 0.8833922}
-  m_LocalPosition: {x: 3.958121e-11, y: 0.0012276003, z: -5.5879353e-11}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6823943722715742366}
-  m_Father: {fileID: 878801516069457118}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &859133973676865526
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 443253582784135126}
-  m_Layer: 0
-  m_Name: thumb_03_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &443253582784135126
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 859133973676865526}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.139098, y: -0.04476655, z: -0.024881518, w: 0.9889533}
-  m_LocalPosition: {x: 2.2351741e-10, y: 0.00032632975, z: -4.4703483e-10}
-  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7231893877072769208}
-  m_Father: {fileID: 7164898174150959210}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &899191278455735979
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2585025911604653489}
-  m_Layer: 0
-  m_Name: middle_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2585025911604653489
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 899191278455735979}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.09070528, y: 0.4362384, z: -0.15371408, w: 0.8819527}
-  m_LocalPosition: {x: 0.000015773103, y: 0.00091474666, z: -0.00010702905}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2748903378610732510}
-  m_Father: {fileID: 3218137277628518561}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &952230941020806774
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 49697105603378068}
-  - component: {fileID: 2332716315541233330}
-  - component: {fileID: 3556038062475546210}
-  m_Layer: 0
-  m_Name: HipsFrontLeftSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &49697105603378068
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952230941020806774}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
-  m_LocalPosition: {x: -0.141, y: 1.001, z: 0.091}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2332716315541233330
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952230941020806774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 8
---- !u!114 &3556038062475546210
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 952230941020806774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 49697105603378068}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &1022032228430840615
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1619068815029867637}
-  m_Layer: 0
-  m_Name: ball_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1619068815029867637
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1022032228430840615}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.24330804, y: 0.39314923, z: -0.07650533, w: 0.8833922}
-  m_LocalPosition: {x: -3.958121e-11, y: 0.0012276003, z: -5.5879353e-11}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1226378886050586736}
-  m_Father: {fileID: 4357164833074477120}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1050893344768583632
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4020431684755180032}
-  m_Layer: 0
-  m_Name: ring_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4020431684755180032
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1050893344768583632}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.050464388, y: -0.014995406, z: 0.021539208, w: 0.99838096}
-  m_LocalPosition: {x: -1.4901161e-10, y: 0.00022469096, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8871443257903065354}
-  m_Father: {fileID: 8508388309272853131}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1059292216483788786
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6793700598593668609}
-  - component: {fileID: 4416493588786601080}
-  - component: {fileID: 7397466181889588822}
-  m_Layer: 0
-  m_Name: LeftBackSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6793700598593668609
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1059292216483788786}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.72605973, y: 0.000000014901156, z: -0, w: 0.68763167}
-  m_LocalPosition: {x: -0.095, y: 1.393, z: -0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
-  m_LocalEulerAnglesHint: {x: 93.11401, y: 0, z: 0}
---- !u!114 &4416493588786601080
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1059292216483788786}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 7
---- !u!114 &7397466181889588822
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1059292216483788786}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 6793700598593668609}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &1280611306940192732
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7966273261143993405}
-  m_Layer: 0
-  m_Name: lowerarm_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7966273261143993405
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1280611306940192732}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.33205488, y: -0.029050918, z: -0.020732732, w: 0.94258463}
-  m_LocalPosition: {x: 0.000000001169974, y: 0.0023226484, z: 3.259629e-11}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3218137277628518561}
-  m_Father: {fileID: 2977808627005992395}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1355481591162106875
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7231893877072769208}
-  m_Layer: 0
-  m_Name: thumb_03_r_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7231893877072769208
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1355481591162106875}
+  m_GameObject: {fileID: 583566657351229366}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0002571491, z: 0}
+  m_LocalPosition: {x: -0, y: 0.00024752432, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 443253582784135126}
+  m_Father: {fileID: 1616949082261745534}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1550342487499285337
+--- !u!1 &685427636604770516
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -990,159 +342,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5766205612837325071}
+  - component: {fileID: 656202537569593019}
   m_Layer: 0
-  m_Name: middle_03_l_end
+  m_Name: index_02_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5766205612837325071
+--- !u!4 &656202537569593019
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1550342487499285337}
+  m_GameObject: {fileID: 685427636604770516}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0002454759, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3357482638972456079}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1620586207191091112
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7786586981119059343}
-  - component: {fileID: 6024737840682569337}
-  - component: {fileID: 6538742769525404962}
-  m_Layer: 0
-  m_Name: LeftUpperArmSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7786586981119059343
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1620586207191091112}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
-  m_LocalPosition: {x: -0.346, y: 1.386, z: -0.061}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6024737840682569337
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1620586207191091112}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 4
---- !u!114 &6538742769525404962
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1620586207191091112}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 7786586981119059343}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &1648787097965190033
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2327651429292842644}
-  m_Layer: 0
-  m_Name: index_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2327651429292842644
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1648787097965190033}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.10870225, y: 0.50240475, z: -0.0064722584, w: 0.85774785}
-  m_LocalPosition: {x: -0.00011416673, y: 0.00095111236, z: 0.00009172072}
+  m_LocalRotation: {x: 0.11140718, y: 0.013497079, z: 0.005104303, w: 0.9936701}
+  m_LocalPosition: {x: 1.4901161e-10, y: 0.000233686, z: 4.4703483e-10}
   m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6756154929407266958}
-  m_Father: {fileID: 3218137277628518561}
+  - {fileID: 4335524568324716511}
+  m_Father: {fileID: 2994304473762515553}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1726083391964276931
+--- !u!1 &686328753748536572
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1150,96 +374,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 115146769632896785}
-  - component: {fileID: 5259288324312152689}
-  - component: {fileID: 8973153682573427477}
+  - component: {fileID: 738403958125762811}
   m_Layer: 0
-  m_Name: LeftHandSocket
+  m_Name: neck_01
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &115146769632896785
+--- !u!4 &738403958125762811
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1726083391964276931}
+  m_GameObject: {fileID: 686328753748536572}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
-  m_LocalPosition: {x: -0.802, y: 1.353, z: -0.017}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: 0.18639033, y: 0, z: -0, w: 0.9824758}
+  m_LocalPosition: {x: -0, y: 0.002951688, z: -0.00013792946}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
+  m_Children:
+  - {fileID: 7382531197968042743}
+  m_Father: {fileID: 4627148517924441137}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5259288324312152689
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1726083391964276931}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 1
---- !u!114 &8973153682573427477
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1726083391964276931}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 115146769632896785}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &1817690284683143635
+--- !u!1 &919285485663878952
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1247,102 +406,37 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1771497804972488078}
+  - component: {fileID: 6657928999061843591}
+  - component: {fileID: 4842143753334600935}
   m_Layer: 0
-  m_Name: AnimationRigging
+  m_Name: Human.ponytail01.001_export_copy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1771497804972488078
+--- !u!4 &6657928999061843591
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1817690284683143635}
+  m_GameObject: {fileID: 919285485663878952}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 476706900746659774}
-  - {fileID: 6679147089115509129}
-  m_Father: {fileID: 6556864370830939371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1880491512700122555
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2977808627005992395}
-  m_Layer: 0
-  m_Name: upperarm_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2977808627005992395
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1880491512700122555}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0012128224, y: -0.0042772186, z: -0.35152513, w: 0.9361679}
-  m_LocalPosition: {x: -0.0000000015442492, y: 0.0013192963, z: -9.3132255e-12}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7966273261143993405}
-  m_Father: {fileID: 7962876818088788929}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1891439976408290528
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5108216991000040777}
-  - component: {fileID: 1693748501933919309}
-  m_Layer: 0
-  m_Name: Human.elvs_crude_t-shirt_male_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5108216991000040777
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1891439976408290528}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 1.181, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6556864370830939371}
+  m_Father: {fileID: 8229891078867211912}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &1693748501933919309
+--- !u!137 &4842143753334600935
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1891439976408290528}
+  m_GameObject: {fileID: 919285485663878952}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -1353,10 +447,15 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: ff7264b6de227934aa70f5af5cb1bb81, type: 2}
+  - {fileID: 2100000, guid: 2b6c142490181a7469aa8c0782e8ede7, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -1374,75 +473,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -7409952842778989114, guid: 202215a518327c145ad063e646529afb, type: 3}
+  m_Mesh: {fileID: 6605115748870570492, guid: 202215a518327c145ad063e646529afb, type: 3}
   m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
+  m_RootBone: {fileID: 8219266566289854322}
   m_AABB:
-    m_Center: {x: -0.00000014691614, y: -0.00044457288, z: 0.010774053}
-    m_Extent: {x: 0.0027704944, y: 0.0022029327, z: 0.003138908}
+    m_Center: {x: 0.00000940368, y: 0.00017393427, z: 0.014227368}
+    m_Extent: {x: 0.0007383467, y: 0.0015061703, z: 0.0018002801}
   m_DirtyAABB: 0
---- !u!1 &1901282591646463896
+--- !u!1 &983784427752502593
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1450,242 +551,51 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8508388309272853131}
+  - component: {fileID: 3354435046558667152}
+  - component: {fileID: 5298395296439996351}
+  - component: {fileID: 8603611743745632417}
   m_Layer: 0
-  m_Name: ring_02_l
+  m_Name: HipsFrontLeftSocket
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8508388309272853131
+--- !u!4 &3354435046558667152
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1901282591646463896}
+  m_GameObject: {fileID: 983784427752502593}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.06498775, y: -0.0013483997, z: -0.038200963, w: 0.9971537}
-  m_LocalPosition: {x: -0, y: 0.00026923156, z: 3.72529e-10}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4020431684755180032}
-  m_Father: {fileID: 2384772739249853786}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1959257943414188570
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1913618082039558947}
-  m_Layer: 0
-  m_Name: thumb_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1913618082039558947
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1959257943414188570}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.2678964, y: 0.7676114, z: 0.44123837, w: -0.3798855}
-  m_LocalPosition: {x: 0.00011907972, y: 0.00035285592, z: 0.00014389094}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5081651697852610259}
-  m_Father: {fileID: 7475567377736111956}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1980566645157199365
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3964992522341908183}
-  m_Layer: 0
-  m_Name: pinky_02_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3964992522341908183
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1980566645157199365}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.078891, y: 0.0090751145, z: 0.026954947, w: 0.9964775}
-  m_LocalPosition: {x: -0, y: 0.0001933509, z: 5.2154064e-10}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2197915236501710594}
-  m_Father: {fileID: 5167699246143570303}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2040676745369034675
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4816521224016380050}
-  m_Layer: 0
-  m_Name: ring_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4816521224016380050
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040676745369034675}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.040599264, y: 0.41200596, z: -0.22933434, w: 0.8809135}
-  m_LocalPosition: {x: 0.00013238414, y: 0.00084851874, z: -0.00022943699}
-  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.9999999}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5443847966725506001}
-  m_Father: {fileID: 3218137277628518561}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2081717180644882789
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6371815981929807372}
-  m_Layer: 0
-  m_Name: pinky_03_l_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6371815981929807372
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2081717180644882789}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00018041601, z: 0}
+  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
+  m_LocalPosition: {x: -0.141, y: 1.001, z: 0.091}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7428004973393321993}
+  m_Father: {fileID: 410635904188027050}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2085019875475350111
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5854730527138204882}
-  m_Layer: 0
-  m_Name: upperarm_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5854730527138204882
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2085019875475350111}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0012128224, y: 0.0042772186, z: 0.35152513, w: 0.9361679}
-  m_LocalPosition: {x: 0.0000000015442492, y: 0.0013192963, z: -9.3132255e-12}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3089149444703835992}
-  m_Father: {fileID: 5226247515357520334}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2246941975032622878
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5390393892021376998}
-  - component: {fileID: 573214661464599373}
-  - component: {fileID: 3053929315492818821}
-  m_Layer: 0
-  m_Name: RightHandSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5390393892021376998
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2246941975032622878}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.04324497, y: -0.056759395, z: -0.70398045, w: 0.7066256}
-  m_LocalPosition: {x: 0.787, y: 1.355, z: 0.005}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &573214661464599373
+--- !u!114 &5298395296439996351
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2246941975032622878}
+  m_GameObject: {fileID: 983784427752502593}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 0
---- !u!114 &3053929315492818821
+  <SocketId>k__BackingField: 8
+--- !u!114 &8603611743745632417
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2246941975032622878}
+  m_GameObject: {fileID: 983784427752502593}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -1693,11 +603,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 5390393892021376998}
+    m_ConstrainedObject: {fileID: 3354435046558667152}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 342574450868786768}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -1730,7 +640,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &2292698746178493765
+--- !u!1 &1038631645467022283
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1738,9 +648,170 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 350850321662862790}
-  - component: {fileID: 3289303617607310642}
-  - component: {fileID: 182784343717679398}
+  - component: {fileID: 4006974465236572899}
+  m_Layer: 0
+  m_Name: lowerarm_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4006974465236572899
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1038631645467022283}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.33205488, y: 0.029050918, z: 0.020732732, w: 0.94258463}
+  m_LocalPosition: {x: -0.000000001169974, y: 0.0023226484, z: 3.259629e-11}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3410024656194104272}
+  m_Father: {fileID: 8689966920897482429}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1124198546960366358
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6301272783317506121}
+  - component: {fileID: 4217399593310877528}
+  - component: {fileID: 1759598203096379946}
+  m_Layer: 0
+  m_Name: RightLowerArmSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6301272783317506121
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124198546960366358}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.050784193, y: -0.06303089, z: -0.713447, w: 0.6960184}
+  m_LocalPosition: {x: 0.31054264, y: 1.0918921, z: 0.02438879}
+  m_LocalScale: {x: 0.9999998, y: 0.99999964, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410635904188027050}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4217399593310877528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124198546960366358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 2
+--- !u!114 &1759598203096379946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1124198546960366358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 6301272783317506121}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 1069430019985569169}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &1166067174481690218
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1151282446492632663}
+  m_Layer: 0
+  m_Name: ring_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1151282446492632663
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166067174481690218}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.040599264, y: 0.41200596, z: -0.22933434, w: 0.8809135}
+  m_LocalPosition: {x: 0.00013238414, y: 0.00084851874, z: -0.00022943699}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4326347100290123948}
+  m_Father: {fileID: 4309342630357203679}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1284763865998149004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7843781460543995551}
+  - component: {fileID: 1246665931794519055}
+  - component: {fileID: 7745958410504067028}
   m_Layer: 0
   m_Name: Spine Aim
   m_TagString: Untagged
@@ -1748,28 +819,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &350850321662862790
+--- !u!4 &7843781460543995551
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2292698746178493765}
+  m_GameObject: {fileID: 1284763865998149004}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6679147089115509129}
+  m_Father: {fileID: 5389314231816542757}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3289303617607310642
+--- !u!114 &1246665931794519055
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2292698746178493765}
+  m_GameObject: {fileID: 1284763865998149004}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
@@ -1777,21 +848,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 0
   m_Effectors: []
---- !u!114 &182784343717679398
+--- !u!114 &7745958410504067028
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2292698746178493765}
+  m_GameObject: {fileID: 1284763865998149004}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Weight: 1
+  m_Weight: 0
   m_Data:
-    m_ConstrainedObject: {fileID: 0}
+    m_ConstrainedObject: {fileID: 2851911031149534541}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
@@ -1826,12 +897,12 @@ MonoBehaviour:
     m_WorldUpType: 0
     m_WorldUpObject: {fileID: 0}
     m_WorldUpAxis: 2
-    m_MaintainOffset: 0
+    m_MaintainOffset: 1
     m_ConstrainedAxes:
       x: 1
       y: 1
       z: 1
---- !u!1 &2441037868725559646
+--- !u!1 &1499196871432175330
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1839,62 +910,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5081651697852610259}
+  - component: {fileID: 2920973400686734298}
   m_Layer: 0
-  m_Name: thumb_02_l
+  m_Name: ring_03_r_end
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5081651697852610259
+--- !u!4 &2920973400686734298
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2441037868725559646}
+  m_GameObject: {fileID: 1499196871432175330}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.08915367, y: 0.011068207, z: 0.17301637, w: 0.9808132}
-  m_LocalPosition: {x: -4.4703483e-10, y: 0.00027966185, z: -1.11758706e-10}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 966263828761334213}
-  m_Father: {fileID: 1913618082039558947}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2442281243515537116
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 668361500271134519}
-  m_Layer: 0
-  m_Name: Left Leg IK_target
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &668361500271134519
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2442281243515537116}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.8550024, y: -0.013999376, z: 0.02312521, w: 0.517919}
-  m_LocalPosition: {x: -0.089982, y: 0.10216425, z: -0.050898075}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00024307752, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3512924333770603322}
+  m_Father: {fileID: 5921673061741191239}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2827248256403700998
+--- !u!1 &1516991868482779784
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1902,33 +941,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5844555597785276875}
+  - component: {fileID: 6831215402655570018}
   m_Layer: 0
-  m_Name: spine_03
+  m_Name: pinky_03_l_end
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5844555597785276875
+--- !u!4 &6831215402655570018
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2827248256403700998}
+  m_GameObject: {fileID: 1516991868482779784}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.065681174, y: 0, z: -0, w: 0.9978407}
-  m_LocalPosition: {x: -0, y: 0.0009107218, z: 1.8626451e-11}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00018041601, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5226247515357520334}
-  - {fileID: 7962876818088788929}
-  - {fileID: 7419604829825494110}
-  m_Father: {fileID: 1058978345447164408}
+  m_Children: []
+  m_Father: {fileID: 1300560289145079763}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2947485682207260327
+--- !u!1 &1518411982067013231
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1936,172 +972,51 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3512924333770603322}
-  - component: {fileID: 3017391356730333353}
-  - component: {fileID: 945119980830488111}
+  - component: {fileID: 8331532877906613585}
+  - component: {fileID: 1212888279936797037}
+  - component: {fileID: 7648940971209705793}
   m_Layer: 0
-  m_Name: Left Leg IK
+  m_Name: RightUpperArmSocket
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3512924333770603322
+--- !u!4 &8331532877906613585
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2947485682207260327}
+  m_GameObject: {fileID: 1518411982067013231}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 668361500271134519}
-  - {fileID: 2605447370435170265}
-  m_Father: {fileID: 6679147089115509129}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3017391356730333353
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2947485682207260327}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Effectors:
-  - m_Transform: {fileID: 668361500271134519}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 2605447370435170265}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 0}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 2605447370435170265}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 668361500271134519}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 2605447370435170265}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
---- !u!114 &945119980830488111
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2947485682207260327}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_Root: {fileID: 0}
-    m_Mid: {fileID: 0}
-    m_Tip: {fileID: 0}
-    m_Target: {fileID: 668361500271134519}
-    m_Hint: {fileID: 2605447370435170265}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 0
-    m_MaintainTargetPositionOffset: 1
-    m_MaintainTargetRotationOffset: 1
---- !u!1 &2981469842606643177
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4108920179095155388}
-  - component: {fileID: 3338809348084394965}
-  - component: {fileID: 1894246999642477883}
-  m_Layer: 0
-  m_Name: RightLowerArmSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4108920179095155388
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2981469842606643177}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.050784193, y: -0.06303089, z: -0.713447, w: 0.6960184}
-  m_LocalPosition: {x: 0.548, y: 1.386, z: -0.045}
+  m_LocalRotation: {x: 0.050784163, y: -0.06303089, z: -0.713447, w: 0.69601834}
+  m_LocalPosition: {x: 0.15386587, y: 1.2633141, z: 0.02066636}
   m_LocalScale: {x: 0.9999998, y: 0.99999964, z: 0.99999976}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 476706900746659774}
+  m_Father: {fileID: 410635904188027050}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3338809348084394965
+--- !u!114 &1212888279936797037
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2981469842606643177}
+  m_GameObject: {fileID: 1518411982067013231}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 2
---- !u!114 &1894246999642477883
+  <SocketId>k__BackingField: 5
+--- !u!114 &7648940971209705793
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2981469842606643177}
+  m_GameObject: {fileID: 1518411982067013231}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -2109,11 +1024,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 4108920179095155388}
+    m_ConstrainedObject: {fileID: 8331532877906613585}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 8042139431053797484}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -2146,7 +1061,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &3049630744427843255
+--- !u!1 &1581222663141992663
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2154,83 +1069,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6679147089115509129}
-  - component: {fileID: 7531143227365579660}
+  - component: {fileID: 6073868566241321646}
   m_Layer: 0
-  m_Name: CharacterRig
+  m_Name: thumb_02_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6679147089115509129
+--- !u!4 &6073868566241321646
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3049630744427843255}
+  m_GameObject: {fileID: 1581222663141992663}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: 0.08915367, y: -0.011068207, z: -0.17301637, w: 0.9808132}
+  m_LocalPosition: {x: 4.4703483e-10, y: 0.00027966185, z: -1.11758706e-10}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7104467115324206679}
-  - {fileID: 4895412048737233965}
-  - {fileID: 3512924333770603322}
-  - {fileID: 4714683466456701201}
-  - {fileID: 350850321662862790}
-  - {fileID: 8889706388199405616}
-  m_Father: {fileID: 1771497804972488078}
+  - {fileID: 5539494183430966140}
+  m_Father: {fileID: 5615530770860326887}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7531143227365579660
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3049630744427843255}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Effectors:
-  - m_Transform: {fileID: 6318818416349053219}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 3896762046793676302}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 0, g: 0.031424046, b: 1, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 5813472414841403969}
-    m_Style:
-      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
-      color: {r: 0, g: 0.045587063, b: 1, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 4740035597959613377}
-    m_Style:
-      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
---- !u!1 &3095225969320012118
+--- !u!1 &1612010828520782950
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2238,96 +1101,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7440119764428091295}
-  - component: {fileID: 1475095046850196577}
-  - component: {fileID: 6214558310680322836}
+  - component: {fileID: 6529172150956068362}
   m_Layer: 0
-  m_Name: LeftLowerArmSocket
+  m_Name: Human.003.rig_export_copy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7440119764428091295
+--- !u!4 &6529172150956068362
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3095225969320012118}
+  m_GameObject: {fileID: 1612010828520782950}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
-  m_LocalPosition: {x: -0.575, y: 1.387, z: -0.05}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071067}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 100, y: 100, z: 100}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
+  m_Children:
+  - {fileID: 8219266566289854322}
+  m_Father: {fileID: 8229891078867211912}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1475095046850196577
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3095225969320012118}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 3
---- !u!114 &6214558310680322836
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3095225969320012118}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 7440119764428091295}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &3167300597571267454
+--- !u!1 &1676463820691342943
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2335,66 +1133,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1226378886050586736}
+  - component: {fileID: 4580032715661766560}
   m_Layer: 0
-  m_Name: ball_r_end
+  m_Name: middle_03_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1226378886050586736
+--- !u!4 &4580032715661766560
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3167300597571267454}
+  m_GameObject: {fileID: 1676463820691342943}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0006135696, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1619068815029867637}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3370159751816284222
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7475567377736111956}
-  m_Layer: 0
-  m_Name: hand_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7475567377736111956
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3370159751816284222}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.118581474, y: -0.41475782, z: 0.019121481, w: 0.9019694}
-  m_LocalPosition: {x: 3.5390257e-10, y: 0.0021085977, z: -2.9802322e-10}
+  m_LocalRotation: {x: 0.06620053, y: 0.008922866, z: -0.0063932124, w: 0.997746}
+  m_LocalPosition: {x: -0, y: 0.00025188894, z: 7.4505804e-11}
   m_LocalScale: {x: 1, y: 1.0000001, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3693122853774783904}
-  - {fileID: 7886245317946361237}
-  - {fileID: 3961867463947060886}
-  - {fileID: 2384772739249853786}
-  - {fileID: 1913618082039558947}
-  m_Father: {fileID: 3089149444703835992}
+  - {fileID: 5770069624265261197}
+  m_Father: {fileID: 4570561004290500836}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3446923917728569710
+--- !u!1 &1732848943944926019
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2402,538 +1165,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7626238475126533065}
-  m_Layer: 0
-  m_Name: thumb_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7626238475126533065
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3446923917728569710}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.2678964, y: 0.7676114, z: 0.44123837, w: 0.3798855}
-  m_LocalPosition: {x: -0.00011907972, y: 0.00035285592, z: 0.00014389094}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7164898174150959210}
-  m_Father: {fileID: 3218137277628518561}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3556086350840802026
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7934664580478894630}
-  m_Layer: 0
-  m_Name: index_03_r_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7934664580478894630
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3556086350840802026}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00024752432, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 811254722774896985}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4216008547691427823
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8647527434660935863}
-  m_Layer: 0
-  m_Name: index_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8647527434660935863
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4216008547691427823}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.11140718, y: -0.013497079, z: -0.005104303, w: 0.9936701}
-  m_LocalPosition: {x: -1.4901161e-10, y: 0.000233686, z: 4.4703483e-10}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7861684926067814557}
-  m_Father: {fileID: 3693122853774783904}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4252612032027343546
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3693122853774783904}
-  m_Layer: 0
-  m_Name: index_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3693122853774783904
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4252612032027343546}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.10870225, y: -0.50240475, z: 0.0064722584, w: 0.85774785}
-  m_LocalPosition: {x: 0.00011416673, y: 0.00095111236, z: 0.00009172072}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8647527434660935863}
-  m_Father: {fileID: 7475567377736111956}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4322018792581399184
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7187109664535410002}
-  m_Layer: 0
-  m_Name: Right Leg IK_target
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7187109664535410002
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4322018792581399184}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.8550025, y: 0.013999425, z: -0.02312513, w: 0.51791894}
-  m_LocalPosition: {x: 0.08998204, y: 0.102164164, z: -0.050898165}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4714683466456701201}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4372737479163855149
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3896762046793676302}
-  m_Layer: 0
-  m_Name: LH IK Target
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3896762046793676302
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4372737479163855149}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.043244887, y: 0.05675955, z: 0.7039805, w: 0.7066255}
-  m_LocalPosition: {x: -0.867, y: 1.383, z: 0.007}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4895412048737233965}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4421560773561159877
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5265577630889745494}
-  m_Layer: 0
-  m_Name: thigh_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5265577630889745494
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4421560773561159877}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.9475263, y: -0.10418324, z: 0.20727295, w: -0.21994945}
-  m_LocalPosition: {x: -0.0009458223, y: -0.00006587047, z: -0.00011003237}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000011}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 481046659775080012}
-  m_Father: {fileID: 4519945923185583371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4698623800364344916
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6318818416349053219}
-  m_Layer: 0
-  m_Name: RH IK Target
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6318818416349053219
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4698623800364344916}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.043244947, y: -0.056759432, z: -0.70398045, w: 0.7066256}
-  m_LocalPosition: {x: 0.676, y: 1.385, z: 0.081}
-  m_LocalScale: {x: 1.0000005, y: 1.0000004, z: 1.0000001}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7104467115324206679}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4727645639763839390
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5813472414841403969}
-  m_Layer: 0
-  m_Name: LH IK Hint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5813472414841403969
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4727645639763839390}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.050784223, y: 0.06303089, z: 0.7134469, w: 0.6960184}
-  m_LocalPosition: {x: -0.295, y: 1.108, z: -0.192}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4895412048737233965}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4991786299421103454
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8262643260755564265}
-  m_Layer: 0
-  m_Name: middle_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8262643260755564265
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4991786299421103454}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0486796, y: -0.0050305324, z: -0.035270266, w: 0.99817884}
-  m_LocalPosition: {x: -0, y: 0.00030750938, z: 2.9802322e-10}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3357482638972456079}
-  m_Father: {fileID: 7886245317946361237}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5157939995509146203
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7104467115324206679}
-  - component: {fileID: 2691302938270690217}
-  m_Layer: 0
-  m_Name: Right Arm IK
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7104467115324206679
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5157939995509146203}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6318818416349053219}
-  - {fileID: 4740035597959613377}
-  m_Father: {fileID: 6679147089115509129}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2691302938270690217
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5157939995509146203}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Data:
-    m_Root: {fileID: 2977808627005992395}
-    m_Mid: {fileID: 7966273261143993405}
-    m_Tip: {fileID: 3218137277628518561}
-    m_Target: {fileID: 6318818416349053219}
-    m_Hint: {fileID: 4740035597959613377}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 1
-    m_MaintainTargetPositionOffset: 0
-    m_MaintainTargetRotationOffset: 0
---- !u!1 &5303856323378367472
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2605447370435170265}
-  m_Layer: 0
-  m_Name: Left Leg IK_hint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2605447370435170265
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5303856323378367472}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.16571158, y: 0.42413455, z: 0.7723244}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3512924333770603322}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5313604379722685820
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7311315713009681036}
-  m_Layer: 0
-  m_Name: index_03_l_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7311315713009681036
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5313604379722685820}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00024752432, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7861684926067814557}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5442213242187869293
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7962876818088788929}
-  m_Layer: 0
-  m_Name: clavicle_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7962876818088788929
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5442213242187869293}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.013533592, y: -0.0062335213, z: -0.7455621, w: 0.6662696}
-  m_LocalPosition: {x: 0.0002277269, y: 0.002273369, z: 0.00009345285}
-  m_LocalScale: {x: 0.9999998, y: 0.9999999, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2977808627005992395}
-  m_Father: {fileID: 5844555597785276875}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5612457644274490227
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3961867463947060886}
-  m_Layer: 0
-  m_Name: pinky_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3961867463947060886
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5612457644274490227}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.03308608, y: -0.3156204, z: 0.30610266, w: 0.89754677}
-  m_LocalPosition: {x: -0.00027408436, y: 0.00075175596, z: -0.00031188448}
-  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 255935697792563320}
-  m_Father: {fileID: 7475567377736111956}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5624157358072323729
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7886245317946361237}
-  m_Layer: 0
-  m_Name: middle_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7886245317946361237
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5624157358072323729}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.09070528, y: -0.4362384, z: 0.15371408, w: 0.8819527}
-  m_LocalPosition: {x: -0.000015773103, y: 0.00091474666, z: -0.00010702905}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8262643260755564265}
-  m_Father: {fileID: 7475567377736111956}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5698883876570530020
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8871443257903065354}
+  - component: {fileID: 1672577866474910467}
   m_Layer: 0
   m_Name: ring_03_l_end
   m_TagString: Untagged
@@ -2941,22 +1173,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8871443257903065354
+--- !u!4 &1672577866474910467
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5698883876570530020}
+  m_GameObject: {fileID: 1732848943944926019}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0.00024307752, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4020431684755180032}
+  m_Father: {fileID: 3619657815403715820}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5705328062910124728
+--- !u!1 &1747515218237831335
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2964,37 +1196,392 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1426295172490650552}
-  - component: {fileID: 2957932524626804478}
+  - component: {fileID: 1714339159582045435}
   m_Layer: 0
-  m_Name: Human.eyelashes02_export_copy
+  m_Name: thumb_02_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1426295172490650552
+--- !u!4 &1714339159582045435
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5705328062910124728}
+  m_GameObject: {fileID: 1747515218237831335}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalRotation: {x: 0.08915367, y: 0.011068207, z: 0.17301637, w: 0.9808132}
+  m_LocalPosition: {x: -4.4703483e-10, y: 0.00027966185, z: -1.11758706e-10}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2072760468485773797}
+  m_Father: {fileID: 8011564336138805084}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1836169247583354396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3410024656194104272}
+  m_Layer: 0
+  m_Name: hand_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3410024656194104272
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1836169247583354396}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.118581474, y: -0.41475782, z: 0.019121481, w: 0.9019694}
+  m_LocalPosition: {x: 3.5390257e-10, y: 0.0021085977, z: -2.9802322e-10}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3505938461272075995}
+  - {fileID: 4892857268816581554}
+  - {fileID: 6259473263663574704}
+  - {fileID: 5967336496010943389}
+  - {fileID: 8011564336138805084}
+  m_Father: {fileID: 4006974465236572899}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1896758298694890025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 220716193089346549}
+  m_Layer: 0
+  m_Name: pinky_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &220716193089346549
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1896758298694890025}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.011243035, y: 0.0031115646, z: -0.013404051, w: 0.9998421}
+  m_LocalPosition: {x: -0, y: 0.00014155026, z: 3.7252902e-11}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1696695994441239283}
+  m_Father: {fileID: 6290355736433417671}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1975934722380552774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8042139431053797484}
+  m_Layer: 0
+  m_Name: upperarm_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8042139431053797484
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1975934722380552774}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0012128224, y: -0.0042772186, z: -0.35152513, w: 0.9361679}
+  m_LocalPosition: {x: -0.0000000015442492, y: 0.0013192963, z: -9.3132255e-12}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1069430019985569169}
+  m_Father: {fileID: 5927012588123972360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2295588792746777775
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5615530770860326887}
+  m_Layer: 0
+  m_Name: thumb_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5615530770860326887
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2295588792746777775}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.2678964, y: 0.7676114, z: 0.44123837, w: 0.3798855}
+  m_LocalPosition: {x: -0.00011907972, y: 0.00035285592, z: 0.00014389094}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6073868566241321646}
+  m_Father: {fileID: 4309342630357203679}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2314407309017024320
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4335524568324716511}
+  m_Layer: 0
+  m_Name: index_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4335524568324716511
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2314407309017024320}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.063697554, y: 0.0026903162, z: 0.021007935, w: 0.9977445}
+  m_LocalPosition: {x: -0, y: 0.0002082094, z: -1.4901161e-10}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4499880974459164217}
+  m_Father: {fileID: 656202537569593019}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2329750312062291862
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7841314864037860936}
+  - component: {fileID: 7338841997444499067}
+  - component: {fileID: 1424818941777045665}
+  m_Layer: 0
+  m_Name: LeftUpperArmSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7841314864037860936
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2329750312062291862}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
+  m_LocalPosition: {x: -0.15386581, y: 1.2633141, z: 0.02066636}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6556864370830939371}
+  m_Father: {fileID: 410635904188027050}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2957932524626804478
+--- !u!114 &7338841997444499067
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2329750312062291862}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 4
+--- !u!114 &1424818941777045665
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2329750312062291862}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 7841314864037860936}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 8689966920897482429}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &2375093674272855406
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3050581719768717455}
+  m_Layer: 0
+  m_Name: middle_03_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3050581719768717455
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2375093674272855406}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0002454759, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2593040849568736513}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2428374438123978981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3467357413285739444}
+  m_Layer: 0
+  m_Name: head_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3467357413285739444
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2428374438123978981}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0014043703, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7382531197968042743}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2489881560186664078
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8156958266633294146}
+  - component: {fileID: 3939600160911428582}
+  m_Layer: 0
+  m_Name: Human.elvs_crude_t-shirt_male_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8156958266633294146
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2489881560186664078}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8229891078867211912}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &3939600160911428582
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5705328062910124728}
+  m_GameObject: {fileID: 2489881560186664078}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -3005,10 +1592,15 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 0b6ac4a09eb2cfe46a7528412b780660, type: 2}
+  - {fileID: 2100000, guid: ff7264b6de227934aa70f5af5cb1bb81, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -3026,75 +1618,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -1026203588049856728, guid: 202215a518327c145ad063e646529afb, type: 3}
+  m_Mesh: {fileID: -7409952842778989114, guid: 202215a518327c145ad063e646529afb, type: 3}
   m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
+  m_RootBone: {fileID: 8219266566289854322}
   m_AABB:
-    m_Center: {x: 0, y: -0.0012420054, z: 0.01486912}
-    m_Extent: {x: 0.0005227534, y: 0.00006389024, z: 0.00008381158}
+    m_Center: {x: -0.00000014691614, y: -0.00044457288, z: 0.010774053}
+    m_Extent: {x: 0.0027704944, y: 0.0022029327, z: 0.003138908}
   m_DirtyAABB: 0
---- !u!1 &5801310147005632243
+--- !u!1 &2525092164581124549
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3102,31 +1696,32 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2384772739249853786}
+  - component: {fileID: 5568684898111774494}
   m_Layer: 0
-  m_Name: ring_01_l
+  m_Name: AnimationRigging
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2384772739249853786
+--- !u!4 &5568684898111774494
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5801310147005632243}
+  m_GameObject: {fileID: 2525092164581124549}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.040599264, y: -0.41200596, z: 0.22933434, w: 0.8809135}
-  m_LocalPosition: {x: -0.00013238414, y: 0.00084851874, z: -0.00022943699}
-  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.9999999}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8508388309272853131}
-  m_Father: {fileID: 7475567377736111956}
+  - {fileID: 410635904188027050}
+  - {fileID: 5389314231816542757}
+  m_Father: {fileID: 8229891078867211912}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5808567833624729957
+--- !u!1 &2647960558464574419
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3134,96 +1729,33 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5383041750695327858}
-  - component: {fileID: 1191809604337366656}
-  - component: {fileID: 2526250841001869050}
+  - component: {fileID: 4627148517924441137}
   m_Layer: 0
-  m_Name: RightUpperArmSocket
+  m_Name: spine_03
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5383041750695327858
+--- !u!4 &4627148517924441137
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5808567833624729957}
+  m_GameObject: {fileID: 2647960558464574419}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.050784163, y: -0.06303089, z: -0.713447, w: 0.69601834}
-  m_LocalPosition: {x: 0.322, y: 1.391, z: -0.082}
-  m_LocalScale: {x: 0.9999998, y: 0.99999964, z: 0.99999976}
+  m_LocalRotation: {x: -0.065681174, y: 0, z: -0, w: 0.9978407}
+  m_LocalPosition: {x: -0, y: 0.0009107218, z: 1.8626451e-11}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
+  m_Children:
+  - {fileID: 1912470366042116046}
+  - {fileID: 5927012588123972360}
+  - {fileID: 738403958125762811}
+  m_Father: {fileID: 7458708668511229004}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1191809604337366656
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5808567833624729957}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 5
---- !u!114 &2526250841001869050
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5808567833624729957}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_ConstrainedObject: {fileID: 5383041750695327858}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 0}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_ConstrainedPositionAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_ConstrainedRotationAxes:
-      x: 1
-      y: 1
-      z: 1
-    m_MaintainPositionOffset: 1
-    m_MaintainRotationOffset: 1
---- !u!1 &5857755047981936479
+--- !u!1 &2836696407037004534
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3231,8 +1763,348 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6403676991521092808}
-  - component: {fileID: 2977265856433226215}
+  - component: {fileID: 5539494183430966140}
+  m_Layer: 0
+  m_Name: thumb_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5539494183430966140
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2836696407037004534}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.139098, y: -0.04476655, z: -0.024881518, w: 0.9889533}
+  m_LocalPosition: {x: 2.2351741e-10, y: 0.00032632975, z: -4.4703483e-10}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8944438468328343222}
+  m_Father: {fileID: 6073868566241321646}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2888043423971944802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3575870282963529581}
+  m_Layer: 0
+  m_Name: Right Leg IK_hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3575870282963529581
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2888043423971944802}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.16571209, y: 0.42413566, z: 0.77232444}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 311986235194651136}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3011876027664738616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7071715735310502665}
+  m_Layer: 0
+  m_Name: Right Leg IK_target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7071715735310502665
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3011876027664738616}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.8550025, y: 0.013999425, z: -0.02312513, w: 0.51791894}
+  m_LocalPosition: {x: 0.08998204, y: 0.102164164, z: -0.050898165}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 311986235194651136}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3021069003985588047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4297562460052155113}
+  m_Layer: 0
+  m_Name: thumb_03_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4297562460052155113
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3021069003985588047}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0002571491, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2072760468485773797}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3169921093198029064
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 11472554110216234}
+  m_Layer: 0
+  m_Name: RH IK Hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &11472554110216234
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3169921093198029064}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.050784223, y: 0.06303089, z: 0.7134469, w: 0.6960184}
+  m_LocalPosition: {x: 0.281, y: 1.122, z: -0.286}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7280777454404120227}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3211930256852439742
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5770069624265261197}
+  m_Layer: 0
+  m_Name: middle_03_r_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5770069624265261197
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3211930256852439742}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0002454759, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4580032715661766560}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3249418467844057303
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7359459400941931864}
+  m_Layer: 0
+  m_Name: RH IK Target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7359459400941931864
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3249418467844057303}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244947, y: -0.056759432, z: -0.70398045, w: 0.7066256}
+  m_LocalPosition: {x: 0.676, y: 1.385, z: 0.081}
+  m_LocalScale: {x: 1.0000005, y: 1.0000004, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7280777454404120227}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3277112629356065770
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7280777454404120227}
+  - component: {fileID: 8811367747448979784}
+  m_Layer: 0
+  m_Name: Right Arm IK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7280777454404120227
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3277112629356065770}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7359459400941931864}
+  - {fileID: 11472554110216234}
+  m_Father: {fileID: 5389314231816542757}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8811367747448979784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3277112629356065770}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_Root: {fileID: 8042139431053797484}
+    m_Mid: {fileID: 1069430019985569169}
+    m_Tip: {fileID: 4309342630357203679}
+    m_Target: {fileID: 7359459400941931864}
+    m_Hint: {fileID: 11472554110216234}
+    m_TargetPositionWeight: 1
+    m_TargetRotationWeight: 1
+    m_HintWeight: 1
+    m_MaintainTargetPositionOffset: 0
+    m_MaintainTargetRotationOffset: 0
+--- !u!1 &3353804539116589911
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6290355736433417671}
+  m_Layer: 0
+  m_Name: pinky_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6290355736433417671
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3353804539116589911}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.078891, y: 0.0090751145, z: 0.026954947, w: 0.9964775}
+  m_LocalPosition: {x: -0, y: 0.0001933509, z: 5.2154064e-10}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 220716193089346549}
+  m_Father: {fileID: 4716333710905206286}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3480095091665958159
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2851911031149534541}
+  m_Layer: 0
+  m_Name: spine_01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2851911031149534541
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3480095091665958159}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.43429017, y: 0, z: -0, w: 0.90077305}
+  m_LocalPosition: {x: -0, y: 0.0008465624, z: -2.7939676e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7458708668511229004}
+  m_Father: {fileID: 342574450868786768}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3553330597515631010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8580869714061137923}
+  - component: {fileID: 7835803957069079826}
   m_Layer: 0
   m_Name: Human.shoes03_export_copy
   m_TagString: Untagged
@@ -3240,28 +2112,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6403676991521092808
+--- !u!4 &8580869714061137923
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5857755047981936479}
+  m_GameObject: {fileID: 3553330597515631010}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6556864370830939371}
+  m_Father: {fileID: 8229891078867211912}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2977265856433226215
+--- !u!137 &7835803957069079826
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5857755047981936479}
+  m_GameObject: {fileID: 3553330597515631010}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -3272,6 +2144,11 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3293,75 +2170,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 3370421961120479937, guid: 202215a518327c145ad063e646529afb, type: 3}
   m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
+  m_RootBone: {fileID: 8219266566289854322}
   m_AABB:
     m_Center: {x: 0, y: -0.000667163, z: 0.0007777708}
     m_Extent: {x: 0.0027812077, y: 0.0017967054, z: 0.0016752644}
   m_DirtyAABB: 0
---- !u!1 &5865934143252103966
+--- !u!1 &3587426610185025832
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3369,564 +2248,51 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5443847966725506001}
+  - component: {fileID: 8591922526348324907}
+  - component: {fileID: 8201295341389428802}
+  - component: {fileID: 3718747269682487488}
   m_Layer: 0
-  m_Name: ring_02_r
+  m_Name: LeftLowerArmSocket
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5443847966725506001
+--- !u!4 &8591922526348324907
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5865934143252103966}
+  m_GameObject: {fileID: 3587426610185025832}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.06498775, y: 0.0013483997, z: 0.038200963, w: 0.9971537}
-  m_LocalPosition: {x: -0, y: 0.00026923156, z: 3.72529e-10}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9050759286411998071}
-  m_Father: {fileID: 4816521224016380050}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5942608792511809854
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7164898174150959210}
-  m_Layer: 0
-  m_Name: thumb_02_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7164898174150959210
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5942608792511809854}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.08915367, y: -0.011068207, z: -0.17301637, w: 0.9808132}
-  m_LocalPosition: {x: 4.4703483e-10, y: 0.00027966185, z: -1.11758706e-10}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 443253582784135126}
-  m_Father: {fileID: 7626238475126533065}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5971887754255424290
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4714683466456701201}
-  - component: {fileID: 5727726354789008707}
-  - component: {fileID: 8487408846043127129}
-  m_Layer: 0
-  m_Name: Right Leg IK
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4714683466456701201
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5971887754255424290}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
+  m_LocalPosition: {x: -0.3105427, y: 1.0918921, z: 0.02438879}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7187109664535410002}
-  - {fileID: 1025002998940056635}
-  m_Father: {fileID: 6679147089115509129}
+  m_Children: []
+  m_Father: {fileID: 410635904188027050}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5727726354789008707
+--- !u!114 &8201295341389428802
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5971887754255424290}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Effectors:
-  - m_Transform: {fileID: 7187109664535410002}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 1025002998940056635}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 7187109664535410002}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 1025002998940056635}
-    m_Style:
-      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 0.1
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
---- !u!114 &8487408846043127129
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5971887754255424290}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_Root: {fileID: 0}
-    m_Mid: {fileID: 0}
-    m_Tip: {fileID: 0}
-    m_Target: {fileID: 7187109664535410002}
-    m_Hint: {fileID: 1025002998940056635}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 0
-    m_MaintainTargetPositionOffset: 1
-    m_MaintainTargetRotationOffset: 1
---- !u!1 &5982004439083432807
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7419604829825494110}
-  m_Layer: 0
-  m_Name: neck_01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7419604829825494110
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5982004439083432807}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.18639033, y: 0, z: -0, w: 0.9824758}
-  m_LocalPosition: {x: -0, y: 0.002951688, z: -0.00013792946}
-  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7248178993507451700}
-  m_Father: {fileID: 5844555597785276875}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6196279287777523916
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1852076776830461685}
-  - component: {fileID: 3649930309758445127}
-  m_Layer: 0
-  m_Name: Human.pants.003_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1852076776830461685
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6196279287777523916}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6556864370830939371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &3649930309758445127
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6196279287777523916}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e8072db1ec6fb6a4f91089da99012ebb, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -5089666599034670919, guid: 202215a518327c145ad063e646529afb, type: 3}
-  m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
-  m_AABB:
-    m_Center: {x: 0.000012514647, y: -0.00041225413, z: 0.0052543953}
-    m_Extent: {x: 0.0026680077, y: 0.0020189339, z: 0.004497526}
-  m_DirtyAABB: 0
---- !u!1 &6232674569400872795
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3218137277628518561}
-  m_Layer: 0
-  m_Name: hand_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3218137277628518561
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6232674569400872795}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.118581474, y: 0.41475782, z: -0.019121481, w: 0.9019694}
-  m_LocalPosition: {x: -3.5390257e-10, y: 0.0021085977, z: -2.9802322e-10}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2327651429292842644}
-  - {fileID: 2585025911604653489}
-  - {fileID: 5167699246143570303}
-  - {fileID: 4816521224016380050}
-  - {fileID: 7626238475126533065}
-  m_Father: {fileID: 7966273261143993405}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6237531146033422574
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 85292284420255197}
-  - component: {fileID: 3312590031343578324}
-  m_Layer: 0
-  m_Name: Human.ponytail01.001_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &85292284420255197
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6237531146033422574}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6556864370830939371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &3312590031343578324
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6237531146033422574}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 2b6c142490181a7469aa8c0782e8ede7, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 6605115748870570492, guid: 202215a518327c145ad063e646529afb, type: 3}
-  m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
-  m_AABB:
-    m_Center: {x: 0.00000940368, y: 0.00017393427, z: 0.014227368}
-    m_Extent: {x: 0.0007383467, y: 0.0015061703, z: 0.0018002801}
-  m_DirtyAABB: 0
---- !u!1 &6267582966488800506
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7103534773830694635}
-  - component: {fileID: 1893586606696381442}
-  - component: {fileID: 3988505327747668760}
-  m_Layer: 0
-  m_Name: HipsFrontRightSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7103534773830694635
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6267582966488800506}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
-  m_LocalPosition: {x: 0.081, y: 0.985, z: 0.107}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1893586606696381442
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6267582966488800506}
+  m_GameObject: {fileID: 3587426610185025832}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 9
---- !u!114 &3988505327747668760
+  <SocketId>k__BackingField: 3
+--- !u!114 &3718747269682487488
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6267582966488800506}
+  m_GameObject: {fileID: 3587426610185025832}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -3934,11 +2300,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 7103534773830694635}
+    m_ConstrainedObject: {fileID: 8591922526348324907}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 4006974465236572899}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -3971,7 +2337,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &6365641825503092763
+--- !u!1 &3619227513449301061
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3979,30 +2345,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1025002998940056635}
+  - component: {fileID: 2994304473762515553}
   m_Layer: 0
-  m_Name: Right Leg IK_hint
+  m_Name: index_01_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1025002998940056635
+--- !u!4 &2994304473762515553
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6365641825503092763}
+  m_GameObject: {fileID: 3619227513449301061}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.16571209, y: 0.42413566, z: 0.77232444}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_LocalRotation: {x: 0.10870225, y: 0.50240475, z: -0.0064722584, w: 0.85774785}
+  m_LocalPosition: {x: -0.00011416673, y: 0.00095111236, z: 0.00009172072}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4714683466456701201}
+  m_Children:
+  - {fileID: 656202537569593019}
+  m_Father: {fileID: 4309342630357203679}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6413696156318148529
+--- !u!1 &3882795173806515336
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4010,38 +2377,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7898197514039042565}
-  m_Layer: 0
-  m_Name: ring_03_r_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7898197514039042565
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6413696156318148529}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00024307752, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9050759286411998071}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6464345313068194653
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3357482638972456079}
+  - component: {fileID: 2593040849568736513}
   m_Layer: 0
   m_Name: middle_03_l
   m_TagString: Untagged
@@ -4049,23 +2385,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3357482638972456079
+--- !u!4 &2593040849568736513
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6464345313068194653}
+  m_GameObject: {fileID: 3882795173806515336}
   serializedVersion: 2
   m_LocalRotation: {x: 0.06620053, y: -0.008922866, z: 0.0063932124, w: 0.997746}
   m_LocalPosition: {x: -0, y: 0.00025188894, z: 7.4505804e-11}
   m_LocalScale: {x: 1, y: 1.0000001, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5766205612837325071}
-  m_Father: {fileID: 8262643260755564265}
+  - {fileID: 3050581719768717455}
+  m_Father: {fileID: 7581396695307459383}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6573102929347610067
+--- !u!1 &3935082069400528536
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4073,31 +2409,127 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 481046659775080012}
+  - component: {fileID: 56571250049399604}
   m_Layer: 0
-  m_Name: calf_l
+  m_Name: index_02_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &481046659775080012
+--- !u!4 &56571250049399604
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6573102929347610067}
+  m_GameObject: {fileID: 3935082069400528536}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.06561347, y: -0.22422159, z: 0.0023185785, w: 0.97232413}
-  m_LocalPosition: {x: 9.313225e-11, y: 0.0037228311, z: 0}
+  m_LocalRotation: {x: 0.11140718, y: -0.013497079, z: -0.005104303, w: 0.9936701}
+  m_LocalPosition: {x: -1.4901161e-10, y: 0.000233686, z: 4.4703483e-10}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1616949082261745534}
+  m_Father: {fileID: 3505938461272075995}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3984163976595765103
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4936391776413713684}
+  m_Layer: 0
+  m_Name: ring_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4936391776413713684
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3984163976595765103}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.06498775, y: -0.0013483997, z: -0.038200963, w: 0.9971537}
+  m_LocalPosition: {x: -0, y: 0.00026923156, z: 3.72529e-10}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3619657815403715820}
+  m_Father: {fileID: 5967336496010943389}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4034008741971840602
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4655419516182394031}
+  m_Layer: 0
+  m_Name: pinky_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4655419516182394031
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4034008741971840602}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.078891, y: -0.0090751145, z: -0.026954947, w: 0.9964775}
+  m_LocalPosition: {x: -0, y: 0.0001933509, z: 5.2154064e-10}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1300560289145079763}
+  m_Father: {fileID: 6259473263663574704}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4123693896653413130
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4570561004290500836}
+  m_Layer: 0
+  m_Name: middle_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4570561004290500836
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4123693896653413130}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0486796, y: 0.0050305324, z: 0.035270266, w: 0.99817884}
+  m_LocalPosition: {x: -0, y: 0.00030750938, z: 2.9802322e-10}
   m_LocalScale: {x: 1, y: 1.0000001, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 878801516069457118}
-  m_Father: {fileID: 5265577630889745494}
+  - {fileID: 4580032715661766560}
+  m_Father: {fileID: 864817994278133829}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6581857064031095630
+--- !u!1 &4506768896796807491
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4105,40 +2537,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8592307629047571670}
-  m_Layer: 0
-  m_Name: Root
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8592307629047571670
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6581857064031095630}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: -6.1001626e-10, z: -0.0000010177492}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4519945923185583371}
-  m_Father: {fileID: 4219102615782077759}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6758240478567930570
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6596221832464820943}
-  - component: {fileID: 7081300766469255247}
+  - component: {fileID: 6239330415846787786}
+  - component: {fileID: 6100757388537802010}
   m_Layer: 0
   m_Name: Human.low-poly.003_export_copy
   m_TagString: Untagged
@@ -4146,28 +2546,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6596221832464820943
+--- !u!4 &6239330415846787786
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6758240478567930570}
+  m_GameObject: {fileID: 4506768896796807491}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6556864370830939371}
+  m_Father: {fileID: 8229891078867211912}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &7081300766469255247
+--- !u!137 &6100757388537802010
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6758240478567930570}
+  m_GameObject: {fileID: 4506768896796807491}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -4178,6 +2578,11 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4199,75 +2604,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 6386326339462532364, guid: 202215a518327c145ad063e646529afb, type: 3}
   m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
+  m_RootBone: {fileID: 8219266566289854322}
   m_AABB:
     m_Center: {x: 0, y: -0.0011416973, z: 0.014874787}
     m_Extent: {x: 0.000427928, y: 0.00011499226, z: 0.00014379248}
   m_DirtyAABB: 0
---- !u!1 &6797323038704608181
+--- !u!1 &4589510013673116512
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4275,7 +2682,233 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4519945923185583371}
+  - component: {fileID: 4716333710905206286}
+  m_Layer: 0
+  m_Name: pinky_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4716333710905206286
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4589510013673116512}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.03308608, y: 0.3156204, z: -0.30610266, w: 0.89754677}
+  m_LocalPosition: {x: 0.00027408436, y: 0.00075175596, z: -0.00031188448}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6290355736433417671}
+  m_Father: {fileID: 4309342630357203679}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4596643647338321256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4309342630357203679}
+  m_Layer: 0
+  m_Name: hand_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4309342630357203679
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4596643647338321256}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.118581474, y: 0.41475782, z: -0.019121481, w: 0.9019694}
+  m_LocalPosition: {x: -3.5390257e-10, y: 0.0021085977, z: -2.9802322e-10}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2994304473762515553}
+  - {fileID: 864817994278133829}
+  - {fileID: 4716333710905206286}
+  - {fileID: 1151282446492632663}
+  - {fileID: 5615530770860326887}
+  m_Father: {fileID: 1069430019985569169}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4699880924273631854
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8689966920897482429}
+  m_Layer: 0
+  m_Name: upperarm_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8689966920897482429
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4699880924273631854}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0012128224, y: 0.0042772186, z: 0.35152513, w: 0.9361679}
+  m_LocalPosition: {x: 0.0000000015442492, y: 0.0013192963, z: -9.3132255e-12}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4006974465236572899}
+  m_Father: {fileID: 1912470366042116046}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4732643901357381575
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4552200095070429695}
+  m_Layer: 0
+  m_Name: ball_l_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4552200095070429695
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4732643901357381575}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0006135696, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2473642875254494553}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4766422052792132158
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3619657815403715820}
+  m_Layer: 0
+  m_Name: ring_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3619657815403715820
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4766422052792132158}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.050464388, y: -0.014995406, z: 0.021539208, w: 0.99838096}
+  m_LocalPosition: {x: -1.4901161e-10, y: 0.00022469096, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1672577866474910467}
+  m_Father: {fileID: 4936391776413713684}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4793316103364824858
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1696695994441239283}
+  m_Layer: 0
+  m_Name: pinky_03_r_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1696695994441239283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4793316103364824858}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.00018041601, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 220716193089346549}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4990968976783729396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6259473263663574704}
+  m_Layer: 0
+  m_Name: pinky_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6259473263663574704
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4990968976783729396}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.03308608, y: -0.3156204, z: 0.30610266, w: 0.89754677}
+  m_LocalPosition: {x: -0.00027408436, y: 0.00075175596, z: -0.00031188448}
+  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4655419516182394031}
+  m_Father: {fileID: 3410024656194104272}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5031115127583999781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 342574450868786768}
   m_Layer: 0
   m_Name: pelvis
   m_TagString: Untagged
@@ -4283,25 +2916,25 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4519945923185583371
+--- !u!4 &342574450868786768
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6797323038704608181}
+  m_GameObject: {fileID: 5031115127583999781}
   serializedVersion: 2
   m_LocalRotation: {x: 0.4830371, y: 0, z: -0, w: 0.8755999}
   m_LocalPosition: {x: -0, y: -0.00023182758, z: 0.008262252}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3794871522770794472}
-  - {fileID: 5265577630889745494}
-  - {fileID: 7007933616048893112}
-  m_Father: {fileID: 8592307629047571670}
+  - {fileID: 2851911031149534541}
+  - {fileID: 9152289806704543833}
+  - {fileID: 9046239492538980212}
+  m_Father: {fileID: 8219266566289854322}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6825845255198237995
+--- !u!1 &5446292823598999390
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4309,31 +2942,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7248178993507451700}
+  - component: {fileID: 5643122131416389896}
   m_Layer: 0
-  m_Name: head
+  m_Name: foot_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7248178993507451700
+--- !u!4 &5643122131416389896
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6825845255198237995}
+  m_GameObject: {fileID: 5446292823598999390}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.21300568, y: 0, z: -0, w: 0.97705096}
-  m_LocalPosition: {x: -0, y: 0.0011310843, z: -1.862645e-10}
+  m_LocalRotation: {x: -0.53481025, y: 0.026531031, z: -0.020641703, w: 0.84430325}
+  m_LocalPosition: {x: -1.132139e-10, y: 0.0037914454, z: 3.259629e-11}
   m_LocalScale: {x: 1, y: 1, z: 1.0000001}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 135831314182999735}
-  m_Father: {fileID: 7419604829825494110}
+  - {fileID: 2159381546251063548}
+  m_Father: {fileID: 7489914242463965228}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6828941847217359594
+--- !u!1 &5484080328722872667
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4341,31 +2974,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 811254722774896985}
+  - component: {fileID: 8011564336138805084}
   m_Layer: 0
-  m_Name: index_03_r
+  m_Name: thumb_01_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &811254722774896985
+--- !u!4 &8011564336138805084
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6828941847217359594}
+  m_GameObject: {fileID: 5484080328722872667}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.063697554, y: 0.0026903162, z: 0.021007935, w: 0.9977445}
-  m_LocalPosition: {x: -0, y: 0.0002082094, z: -1.4901161e-10}
-  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_LocalRotation: {x: -0.2678964, y: 0.7676114, z: 0.44123837, w: -0.3798855}
+  m_LocalPosition: {x: 0.00011907972, y: 0.00035285592, z: 0.00014389094}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7934664580478894630}
-  m_Father: {fileID: 6756154929407266958}
+  - {fileID: 1714339159582045435}
+  m_Father: {fileID: 3410024656194104272}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6939214058043309856
+--- !u!1 &5554238898869335201
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4373,83 +3006,51 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6756154929407266958}
+  - component: {fileID: 1882501571486450629}
+  - component: {fileID: 8654552307183263910}
+  - component: {fileID: 5954195461655671299}
   m_Layer: 0
-  m_Name: index_02_r
+  m_Name: HipsBackRightSocket
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6756154929407266958
+--- !u!4 &1882501571486450629
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6939214058043309856}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.11140718, y: 0.013497079, z: 0.005104303, w: 0.9936701}
-  m_LocalPosition: {x: 1.4901161e-10, y: 0.000233686, z: 4.4703483e-10}
-  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 811254722774896985}
-  m_Father: {fileID: 2327651429292842644}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6958554369674631586
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7212444211669496278}
-  - component: {fileID: 8114361997312633158}
-  - component: {fileID: 8471141991629040356}
-  m_Layer: 0
-  m_Name: HipsBackLeftSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7212444211669496278
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6958554369674631586}
+  m_GameObject: {fileID: 5554238898869335201}
   serializedVersion: 2
   m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
-  m_LocalPosition: {x: -0.122, y: 1.03, z: -0.059}
+  m_LocalPosition: {x: 0.078, y: 1.034, z: -0.076}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 476706900746659774}
+  m_Father: {fileID: 410635904188027050}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8114361997312633158
+--- !u!114 &8654552307183263910
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6958554369674631586}
+  m_GameObject: {fileID: 5554238898869335201}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 10
---- !u!114 &8471141991629040356
+  <SocketId>k__BackingField: 11
+--- !u!114 &5954195461655671299
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6958554369674631586}
+  m_GameObject: {fileID: 5554238898869335201}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -4457,11 +3058,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 7212444211669496278}
+    m_ConstrainedObject: {fileID: 1882501571486450629}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 342574450868786768}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -4494,7 +3095,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &7066036183737573443
+--- !u!1 &5685511652877118454
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4502,39 +3103,180 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4895412048737233965}
-  - component: {fileID: 6693723757930246060}
+  - component: {fileID: 864817994278133829}
   m_Layer: 0
-  m_Name: Left Arm IK
+  m_Name: middle_01_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4895412048737233965
+--- !u!4 &864817994278133829
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7066036183737573443}
+  m_GameObject: {fileID: 5685511652877118454}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0.09070528, y: 0.4362384, z: -0.15371408, w: 0.8819527}
+  m_LocalPosition: {x: 0.000015773103, y: 0.00091474666, z: -0.00010702905}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4570561004290500836}
+  m_Father: {fileID: 4309342630357203679}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5703622399449819033
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4453659736414612958}
+  m_Layer: 0
+  m_Name: LH IK Target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4453659736414612958
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5703622399449819033}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244887, y: 0.05675955, z: 0.7039805, w: 0.7066255}
+  m_LocalPosition: {x: -0.867, y: 1.383, z: 0.007}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7848258744241299121}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5812549198880871118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2180023934890320115}
+  m_Layer: 0
+  m_Name: ball_r_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2180023934890320115
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5812549198880871118}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0006135696, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2159381546251063548}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5851028440430746625
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 311986235194651136}
+  - component: {fileID: 4203629491770698911}
+  - component: {fileID: 7423238105630776296}
+  m_Layer: 0
+  m_Name: Right Leg IK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &311986235194651136
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5851028440430746625}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3896762046793676302}
-  - {fileID: 5813472414841403969}
-  m_Father: {fileID: 6679147089115509129}
+  - {fileID: 7071715735310502665}
+  - {fileID: 3575870282963529581}
+  m_Father: {fileID: 5389314231816542757}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6693723757930246060
+--- !u!114 &4203629491770698911
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7066036183737573443}
+  m_GameObject: {fileID: 5851028440430746625}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Effectors:
+  - m_Transform: {fileID: 7071715735310502665}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 3575870282963529581}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 7071715735310502665}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 3575870282963529581}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!114 &7423238105630776296
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5851028440430746625}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
@@ -4542,17 +3284,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 0
   m_Data:
-    m_Root: {fileID: 5854730527138204882}
-    m_Mid: {fileID: 3089149444703835992}
-    m_Tip: {fileID: 7475567377736111956}
-    m_Target: {fileID: 3896762046793676302}
-    m_Hint: {fileID: 5813472414841403969}
+    m_Root: {fileID: 9046239492538980212}
+    m_Mid: {fileID: 7489914242463965228}
+    m_Tip: {fileID: 5643122131416389896}
+    m_Target: {fileID: 7071715735310502665}
+    m_Hint: {fileID: 3575870282963529581}
     m_TargetPositionWeight: 1
     m_TargetRotationWeight: 1
-    m_HintWeight: 1
-    m_MaintainTargetPositionOffset: 0
-    m_MaintainTargetRotationOffset: 0
---- !u!1 &7147059484711465684
+    m_HintWeight: 0
+    m_MaintainTargetPositionOffset: 1
+    m_MaintainTargetRotationOffset: 1
+--- !u!1 &5867461755025128974
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4560,31 +3302,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7428004973393321993}
+  - component: {fileID: 3505938461272075995}
   m_Layer: 0
-  m_Name: pinky_03_l
+  m_Name: index_01_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7428004973393321993
+--- !u!4 &3505938461272075995
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7147059484711465684}
+  m_GameObject: {fileID: 5867461755025128974}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.011243035, y: -0.0031115646, z: 0.013404051, w: 0.9998421}
-  m_LocalPosition: {x: -0, y: 0.00014155026, z: 3.7252902e-11}
-  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_LocalRotation: {x: 0.10870225, y: -0.50240475, z: 0.0064722584, w: 0.85774785}
+  m_LocalPosition: {x: 0.00011416673, y: 0.00095111236, z: 0.00009172072}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6371815981929807372}
-  m_Father: {fileID: 255935697792563320}
+  - {fileID: 56571250049399604}
+  m_Father: {fileID: 3410024656194104272}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7314207975848631995
+--- !u!1 &5963071709285281364
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4592,31 +3334,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 9050759286411998071}
+  - component: {fileID: 1069430019985569169}
   m_Layer: 0
-  m_Name: ring_03_r
+  m_Name: lowerarm_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &9050759286411998071
+--- !u!4 &1069430019985569169
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7314207975848631995}
+  m_GameObject: {fileID: 5963071709285281364}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.050464388, y: 0.014995406, z: -0.021539208, w: 0.99838096}
-  m_LocalPosition: {x: 1.4901161e-10, y: 0.00022469096, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1.0000001}
+  m_LocalRotation: {x: 0.33205488, y: -0.029050918, z: -0.020732732, w: 0.94258463}
+  m_LocalPosition: {x: 0.000000001169974, y: 0.0023226484, z: 3.259629e-11}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7898197514039042565}
-  m_Father: {fileID: 5443847966725506001}
+  - {fileID: 4309342630357203679}
+  m_Father: {fileID: 8042139431053797484}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7320068206326569632
+--- !u!1 &6240260427768181788
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4624,133 +3366,49 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4740035597959613377}
+  - component: {fileID: 410635904188027050}
+  - component: {fileID: 8753248105300176801}
   m_Layer: 0
-  m_Name: RH IK Hint
+  m_Name: MeshSockets
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4740035597959613377
+--- !u!4 &410635904188027050
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7320068206326569632}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.050784223, y: 0.06303089, z: 0.7134469, w: 0.6960184}
-  m_LocalPosition: {x: 0.281, y: 1.122, z: -0.286}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7104467115324206679}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7325329096136745029
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 255935697792563320}
-  m_Layer: 0
-  m_Name: pinky_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &255935697792563320
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7325329096136745029}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.078891, y: -0.0090751145, z: -0.026954947, w: 0.9964775}
-  m_LocalPosition: {x: -0, y: 0.0001933509, z: 5.2154064e-10}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7428004973393321993}
-  m_Father: {fileID: 3961867463947060886}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7402145358422025858
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5167699246143570303}
-  m_Layer: 0
-  m_Name: pinky_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5167699246143570303
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7402145358422025858}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.03308608, y: 0.3156204, z: -0.30610266, w: 0.89754677}
-  m_LocalPosition: {x: 0.00027408436, y: 0.00075175596, z: -0.00031188448}
-  m_LocalScale: {x: 1, y: 0.99999994, z: 0.9999999}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3964992522341908183}
-  m_Father: {fileID: 3218137277628518561}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7479878566957896107
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8889706388199405616}
-  - component: {fileID: 5408514382232485871}
-  - component: {fileID: 6699501602236300897}
-  m_Layer: 0
-  m_Name: Hip Constraint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8889706388199405616
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7479878566957896107}
+  m_GameObject: {fileID: 6240260427768181788}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6679147089115509129}
+  m_Children:
+  - {fileID: 2190403813663174371}
+  - {fileID: 6885988561491534037}
+  - {fileID: 6301272783317506121}
+  - {fileID: 8591922526348324907}
+  - {fileID: 8331532877906613585}
+  - {fileID: 7841314864037860936}
+  - {fileID: 932753390148264987}
+  - {fileID: 8086587267984074501}
+  - {fileID: 5250072804538552404}
+  - {fileID: 1882501571486450629}
+  - {fileID: 2174184676058747421}
+  - {fileID: 3354435046558667152}
+  m_Father: {fileID: 5568684898111774494}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5408514382232485871
+--- !u!114 &8753248105300176801
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7479878566957896107}
+  m_GameObject: {fileID: 6240260427768181788}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
@@ -4758,13 +3416,985 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Effectors: []
---- !u!114 &6699501602236300897
+--- !u!1 &6280867117718258766
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8373410465839327787}
+  m_Layer: 0
+  m_Name: Hip IK_target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8373410465839327787
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6280867117718258766}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5249136800038137958}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6317054651476064468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4478234207697121360}
+  m_Layer: 0
+  m_Name: Left Leg IK_target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4478234207697121360
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6317054651476064468}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.8550024, y: -0.013999376, z: 0.02312521, w: 0.517919}
+  m_LocalPosition: {x: -0.089982, y: 0.10216425, z: -0.050898075}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8477797510293541801}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6393023403009604864
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1616949082261745534}
+  m_Layer: 0
+  m_Name: index_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1616949082261745534
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6393023403009604864}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.063697554, y: -0.0026903162, z: -0.021007935, w: 0.9977445}
+  m_LocalPosition: {x: -0, y: 0.0002082094, z: -1.4901161e-10}
+  m_LocalScale: {x: 1, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6933541327734477180}
+  m_Father: {fileID: 56571250049399604}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6702809685654294263
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5967336496010943389}
+  m_Layer: 0
+  m_Name: ring_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5967336496010943389
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6702809685654294263}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.040599264, y: -0.41200596, z: 0.22933434, w: 0.8809135}
+  m_LocalPosition: {x: -0.00013238414, y: 0.00084851874, z: -0.00022943699}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.9999999}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4936391776413713684}
+  m_Father: {fileID: 3410024656194104272}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6870455624729956181
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1823408102826035574}
+  - component: {fileID: 2365985820744576889}
+  m_Layer: 0
+  m_Name: Human.eyebrow008.001_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1823408102826035574
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6870455624729956181}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8229891078867211912}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &2365985820744576889
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6870455624729956181}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 34a246b576ca09a4aa8e0f0f9bf907c6, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -4963569351153215188, guid: 202215a518327c145ad063e646529afb, type: 3}
+  m_Bones:
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8219266566289854322}
+  m_AABB:
+    m_Center: {x: 0, y: -0.0012217993, z: 0.0149888415}
+    m_Extent: {x: 0.0005298177, y: 0.00013988616, z: 0.000075032}
+  m_DirtyAABB: 0
+--- !u!1 &6965784207548613109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6885988561491534037}
+  - component: {fileID: 5509349496538299903}
+  - component: {fileID: 4907652996112380347}
+  m_Layer: 0
+  m_Name: LeftHandSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6885988561491534037
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6965784207548613109}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.043244895, y: 0.056759562, z: 0.70398057, w: 0.7066256}
+  m_LocalPosition: {x: -0.44, y: 0.905, z: 0.193}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410635904188027050}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5509349496538299903
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7479878566957896107}
+  m_GameObject: {fileID: 6965784207548613109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 1
+--- !u!114 &4907652996112380347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6965784207548613109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 6885988561491534037}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 3410024656194104272}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &7112314837104981094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4892857268816581554}
+  m_Layer: 0
+  m_Name: middle_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4892857268816581554
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7112314837104981094}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.09070528, y: -0.4362384, z: 0.15371408, w: 0.8819527}
+  m_LocalPosition: {x: -0.000015773103, y: 0.00091474666, z: -0.00010702905}
+  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7581396695307459383}
+  m_Father: {fileID: 3410024656194104272}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7160829014930866282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8976758466170131055}
+  m_Layer: 0
+  m_Name: foot_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8976758466170131055
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7160829014930866282}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.53481025, y: -0.026531031, z: 0.020641703, w: 0.84430325}
+  m_LocalPosition: {x: 1.132139e-10, y: 0.0037914454, z: 3.259629e-11}
+  m_LocalScale: {x: 1, y: 1, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2473642875254494553}
+  m_Father: {fileID: 3602104167289862017}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7191011654699072777
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7382531197968042743}
+  m_Layer: 0
+  m_Name: head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7382531197968042743
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7191011654699072777}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.21300568, y: 0, z: -0, w: 0.97705096}
+  m_LocalPosition: {x: -0, y: 0.0011310843, z: -1.862645e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3467357413285739444}
+  m_Father: {fileID: 738403958125762811}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7362118174612571146
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2174184676058747421}
+  - component: {fileID: 3600949241460403424}
+  - component: {fileID: 6606313045054776164}
+  m_Layer: 0
+  m_Name: HipsFrontRightSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2174184676058747421
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7362118174612571146}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
+  m_LocalPosition: {x: 0.081, y: 0.985, z: 0.107}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410635904188027050}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3600949241460403424
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7362118174612571146}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 9
+--- !u!114 &6606313045054776164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7362118174612571146}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 2174184676058747421}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 342574450868786768}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &7514887357254783543
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7458708668511229004}
+  m_Layer: 0
+  m_Name: spine_02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7458708668511229004
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7514887357254783543}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.10110922, y: 0, z: -0, w: 0.9948753}
+  m_LocalPosition: {x: -0, y: 0.0006650198, z: 1.0633812e-10}
+  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4627148517924441137}
+  m_Father: {fileID: 2851911031149534541}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7686535336762257812
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1912470366042116046}
+  m_Layer: 0
+  m_Name: clavicle_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1912470366042116046
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7686535336762257812}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.013533592, y: 0.0062335213, z: 0.7455621, w: 0.6662696}
+  m_LocalPosition: {x: -0.0002277269, y: 0.002273369, z: 0.00009345285}
+  m_LocalScale: {x: 0.9999998, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8689966920897482429}
+  m_Father: {fileID: 4627148517924441137}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7760729328310046799
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9152289806704543833}
+  m_Layer: 0
+  m_Name: thigh_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9152289806704543833
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7760729328310046799}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.9475263, y: -0.10418324, z: 0.20727295, w: -0.21994945}
+  m_LocalPosition: {x: -0.0009458223, y: -0.00006587047, z: -0.00011003237}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000011}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3602104167289862017}
+  m_Father: {fileID: 342574450868786768}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7811554030558759082
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2072760468485773797}
+  m_Layer: 0
+  m_Name: thumb_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2072760468485773797
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7811554030558759082}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.139098, y: 0.04476655, z: 0.024881518, w: 0.9889533}
+  m_LocalPosition: {x: -2.2351741e-10, y: 0.00032632975, z: -4.4703483e-10}
+  m_LocalScale: {x: 0.99999994, y: 0.9999999, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4297562460052155113}
+  m_Father: {fileID: 1714339159582045435}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7840852461018411344
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5060729341632676252}
+  - component: {fileID: 1601387221984248791}
+  m_Layer: 0
+  m_Name: Human.eyelashes02_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5060729341632676252
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7840852461018411344}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8229891078867211912}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &1601387221984248791
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7840852461018411344}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0b6ac4a09eb2cfe46a7528412b780660, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -1026203588049856728, guid: 202215a518327c145ad063e646529afb, type: 3}
+  m_Bones:
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8219266566289854322}
+  m_AABB:
+    m_Center: {x: 0, y: -0.0012420054, z: 0.01486912}
+    m_Extent: {x: 0.0005227534, y: 0.00006389024, z: 0.00008381158}
+  m_DirtyAABB: 0
+--- !u!1 &7852341691974568146
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3602104167289862017}
+  m_Layer: 0
+  m_Name: calf_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3602104167289862017
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7852341691974568146}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.06561347, y: -0.22422159, z: 0.0023185785, w: 0.97232413}
+  m_LocalPosition: {x: 9.313225e-11, y: 0.0037228311, z: 0}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8976758466170131055}
+  m_Father: {fileID: 9152289806704543833}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7875899666336162756
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7848258744241299121}
+  - component: {fileID: 8076137481123668602}
+  m_Layer: 0
+  m_Name: Left Arm IK
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7848258744241299121
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7875899666336162756}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4453659736414612958}
+  - {fileID: 911552020231453420}
+  m_Father: {fileID: 5389314231816542757}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8076137481123668602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7875899666336162756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_Root: {fileID: 8689966920897482429}
+    m_Mid: {fileID: 4006974465236572899}
+    m_Tip: {fileID: 3410024656194104272}
+    m_Target: {fileID: 4453659736414612958}
+    m_Hint: {fileID: 911552020231453420}
+    m_TargetPositionWeight: 1
+    m_TargetRotationWeight: 1
+    m_HintWeight: 1
+    m_MaintainTargetPositionOffset: 0
+    m_MaintainTargetRotationOffset: 0
+--- !u!1 &7883083341135026106
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5249136800038137958}
+  - component: {fileID: 1781714674275889764}
+  - component: {fileID: 7382914244123314891}
+  m_Layer: 0
+  m_Name: Hip Constraint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5249136800038137958
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7883083341135026106}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8373410465839327787}
+  m_Father: {fileID: 5389314231816542757}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1781714674275889764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7883083341135026106}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Effectors: []
+--- !u!114 &7382914244123314891
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7883083341135026106}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -4772,11 +4402,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 0
   m_Data:
-    m_ConstrainedObject: {fileID: 0}
+    m_ConstrainedObject: {fileID: 342574450868786768}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 8373410465839327787}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -4808,8 +4438,8 @@ MonoBehaviour:
       y: 1
       z: 1
     m_MaintainPositionOffset: 0
-    m_MaintainRotationOffset: 0
---- !u!1 &7521480270016689098
+    m_MaintainRotationOffset: 1
+--- !u!1 &7926991979756694704
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4817,30 +4447,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4105303436502670335}
+  - component: {fileID: 4326347100290123948}
   m_Layer: 0
-  m_Name: middle_03_r_end
+  m_Name: ring_02_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4105303436502670335
+--- !u!4 &4326347100290123948
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7521480270016689098}
+  m_GameObject: {fileID: 7926991979756694704}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0002454759, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: 0.06498775, y: 0.0013483997, z: 0.038200963, w: 0.9971537}
+  m_LocalPosition: {x: -0, y: 0.00026923156, z: 3.72529e-10}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2020823335098461711}
+  m_Children:
+  - {fileID: 5921673061741191239}
+  m_Father: {fileID: 1151282446492632663}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7563272126615367766
+--- !u!1 &7942494144654290816
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4848,37 +4479,37 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7529814817853636081}
-  - component: {fileID: 8904684102136349479}
+  - component: {fileID: 8063266617321443551}
+  - component: {fileID: 6047056178765730140}
   m_Layer: 0
-  m_Name: Human.003_export_copy
+  m_Name: Human.pants.003_export_copy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7529814817853636081
+--- !u!4 &8063266617321443551
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7563272126615367766}
+  m_GameObject: {fileID: 7942494144654290816}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6556864370830939371}
+  m_Father: {fileID: 8229891078867211912}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &8904684102136349479
+--- !u!137 &6047056178765730140
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7563272126615367766}
+  m_GameObject: {fileID: 7942494144654290816}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -4889,10 +4520,15 @@ SkinnedMeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 3
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 4a4518ead8aaa2b48b306b2a13f14197, type: 2}
+  - {fileID: 2100000, guid: e8072db1ec6fb6a4f91089da99012ebb, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -4910,75 +4546,77 @@ SkinnedMeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   serializedVersion: 2
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -8552327251687966643, guid: 202215a518327c145ad063e646529afb, type: 3}
+  m_Mesh: {fileID: -5089666599034670919, guid: 202215a518327c145ad063e646529afb, type: 3}
   m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
+  m_RootBone: {fileID: 8219266566289854322}
   m_AABB:
-    m_Center: {x: 0.0000064154156, y: -0.00035970693, z: 0.008678621}
-    m_Extent: {x: 0.0049420344, y: 0.0026115244, z: 0.007288148}
+    m_Center: {x: 0.000012514647, y: -0.00041225413, z: 0.0052543953}
+    m_Extent: {x: 0.0026680077, y: 0.0020189339, z: 0.004497526}
   m_DirtyAABB: 0
---- !u!1 &7661969381939266298
+--- !u!1 &7947256261685417690
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4986,441 +4624,51 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3794871522770794472}
+  - component: {fileID: 932753390148264987}
+  - component: {fileID: 1024868895857419023}
+  - component: {fileID: 3201174744653874706}
   m_Layer: 0
-  m_Name: spine_01
+  m_Name: RightBackSocket
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3794871522770794472
+--- !u!4 &932753390148264987
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7661969381939266298}
+  m_GameObject: {fileID: 7947256261685417690}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.43429017, y: 0, z: -0, w: 0.90077305}
-  m_LocalPosition: {x: -0, y: 0.0008465624, z: -2.7939676e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1058978345447164408}
-  m_Father: {fileID: 4519945923185583371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7667717710867724073
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3089149444703835992}
-  m_Layer: 0
-  m_Name: lowerarm_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3089149444703835992
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7667717710867724073}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.33205488, y: 0.029050918, z: 0.020732732, w: 0.94258463}
-  m_LocalPosition: {x: -0.000000001169974, y: 0.0023226484, z: 3.259629e-11}
-  m_LocalScale: {x: 0.9999999, y: 1, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7475567377736111956}
-  m_Father: {fileID: 5854730527138204882}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7792740657760656202
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3776138140182054562}
-  - component: {fileID: 8339522634829439376}
-  m_Layer: 0
-  m_Name: Human.tongue01.003_export_copy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3776138140182054562
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7792740657760656202}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalRotation: {x: 0.72605973, y: 0.000000014901156, z: -0, w: 0.68763167}
+  m_LocalPosition: {x: 0.081, y: 1.2821, z: -0.146}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6556864370830939371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &8339522634829439376
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7792740657760656202}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 4b3a05424ed17904c9abf7db18c7470d, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4543397512444452662, guid: 202215a518327c145ad063e646529afb, type: 3}
-  m_Bones:
-  - {fileID: 8592307629047571670}
-  - {fileID: 4519945923185583371}
-  - {fileID: 3794871522770794472}
-  - {fileID: 1058978345447164408}
-  - {fileID: 5844555597785276875}
-  - {fileID: 5226247515357520334}
-  - {fileID: 5854730527138204882}
-  - {fileID: 3089149444703835992}
-  - {fileID: 7475567377736111956}
-  - {fileID: 3693122853774783904}
-  - {fileID: 8647527434660935863}
-  - {fileID: 7861684926067814557}
-  - {fileID: 7886245317946361237}
-  - {fileID: 8262643260755564265}
-  - {fileID: 3357482638972456079}
-  - {fileID: 3961867463947060886}
-  - {fileID: 255935697792563320}
-  - {fileID: 7428004973393321993}
-  - {fileID: 2384772739249853786}
-  - {fileID: 8508388309272853131}
-  - {fileID: 4020431684755180032}
-  - {fileID: 1913618082039558947}
-  - {fileID: 5081651697852610259}
-  - {fileID: 966263828761334213}
-  - {fileID: 7962876818088788929}
-  - {fileID: 2977808627005992395}
-  - {fileID: 7966273261143993405}
-  - {fileID: 3218137277628518561}
-  - {fileID: 2327651429292842644}
-  - {fileID: 6756154929407266958}
-  - {fileID: 811254722774896985}
-  - {fileID: 2585025911604653489}
-  - {fileID: 2748903378610732510}
-  - {fileID: 2020823335098461711}
-  - {fileID: 5167699246143570303}
-  - {fileID: 3964992522341908183}
-  - {fileID: 2197915236501710594}
-  - {fileID: 4816521224016380050}
-  - {fileID: 5443847966725506001}
-  - {fileID: 9050759286411998071}
-  - {fileID: 7626238475126533065}
-  - {fileID: 7164898174150959210}
-  - {fileID: 443253582784135126}
-  - {fileID: 7419604829825494110}
-  - {fileID: 7248178993507451700}
-  - {fileID: 5265577630889745494}
-  - {fileID: 481046659775080012}
-  - {fileID: 878801516069457118}
-  - {fileID: 2311160514431422238}
-  - {fileID: 7007933616048893112}
-  - {fileID: 892847256484991937}
-  - {fileID: 4357164833074477120}
-  - {fileID: 1619068815029867637}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 8592307629047571670}
-  m_AABB:
-    m_Center: {x: 0, y: -0.0009008263, z: 0.0142400805}
-    m_Extent: {x: 0.00021371382, y: 0.00034232042, z: 0.00014314055}
-  m_DirtyAABB: 0
---- !u!1 &7827489503919925246
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 892847256484991937}
-  m_Layer: 0
-  m_Name: calf_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &892847256484991937
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7827489503919925246}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.06561347, y: 0.22422159, z: -0.0023185785, w: 0.97232413}
-  m_LocalPosition: {x: -9.313225e-11, y: 0.0037228311, z: 0}
-  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4357164833074477120}
-  m_Father: {fileID: 7007933616048893112}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7850833685921544748
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 135831314182999735}
-  m_Layer: 0
-  m_Name: head_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &135831314182999735
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7850833685921544748}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0014043703, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7248178993507451700}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8022570678839918261
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6823943722715742366}
-  m_Layer: 0
-  m_Name: ball_l_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6823943722715742366
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8022570678839918261}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0006135696, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2311160514431422238}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8121842334719913093
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4163691610125674352}
-  m_Layer: 0
-  m_Name: thumb_03_l_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4163691610125674352
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8121842334719913093}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.0002571491, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 966263828761334213}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8124825898297380296
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5226247515357520334}
-  m_Layer: 0
-  m_Name: clavicle_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5226247515357520334
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8124825898297380296}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.013533592, y: 0.0062335213, z: 0.7455621, w: 0.6662696}
-  m_LocalPosition: {x: -0.0002277269, y: 0.002273369, z: 0.00009345285}
-  m_LocalScale: {x: 0.9999998, y: 0.9999999, z: 0.99999994}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5854730527138204882}
-  m_Father: {fileID: 5844555597785276875}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8192209544052663226
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 921667459844226887}
-  m_Layer: 0
-  m_Name: pinky_03_r_end
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &921667459844226887
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8192209544052663226}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.00018041601, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2197915236501710594}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8391546088977375460
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3170788153934991080}
-  - component: {fileID: 1728500030757373957}
-  - component: {fileID: 2060521233905865936}
-  m_Layer: 0
-  m_Name: HipsBackRightSocket
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3170788153934991080
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8391546088977375460}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
-  m_LocalPosition: {x: 0.078, y: 1.034, z: -0.076}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 476706900746659774}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1728500030757373957
+  m_Father: {fileID: 410635904188027050}
+  m_LocalEulerAnglesHint: {x: 93.11401, y: 0, z: 0}
+--- !u!114 &1024868895857419023
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8391546088977375460}
+  m_GameObject: {fileID: 7947256261685417690}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <SocketId>k__BackingField: 11
---- !u!114 &2060521233905865936
+  <SocketId>k__BackingField: 6
+--- !u!114 &3201174744653874706
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8391546088977375460}
+  m_GameObject: {fileID: 7947256261685417690}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
@@ -5428,11 +4676,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 1
   m_Data:
-    m_ConstrainedObject: {fileID: 3170788153934991080}
+    m_ConstrainedObject: {fileID: 932753390148264987}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 0}
+        transform: {fileID: 7458708668511229004}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -5465,7 +4713,7 @@ MonoBehaviour:
       z: 1
     m_MaintainPositionOffset: 1
     m_MaintainRotationOffset: 1
---- !u!1 &8447578205427770999
+--- !u!1 &8123890913283393696
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5473,31 +4721,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 878801516069457118}
+  - component: {fileID: 2159381546251063548}
   m_Layer: 0
-  m_Name: foot_l
+  m_Name: ball_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &878801516069457118
+--- !u!4 &2159381546251063548
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8447578205427770999}
+  m_GameObject: {fileID: 8123890913283393696}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.53481025, y: -0.026531031, z: 0.020641703, w: 0.84430325}
-  m_LocalPosition: {x: 1.132139e-10, y: 0.0037914454, z: 3.259629e-11}
-  m_LocalScale: {x: 1, y: 1, z: 1.0000001}
+  m_LocalRotation: {x: -0.24330804, y: 0.39314923, z: -0.07650533, w: 0.8833922}
+  m_LocalPosition: {x: -3.958121e-11, y: 0.0012276003, z: -5.5879353e-11}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2311160514431422238}
-  m_Father: {fileID: 481046659775080012}
+  - {fileID: 2180023934890320115}
+  m_Father: {fileID: 5643122131416389896}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8512674664781212589
+--- !u!1 &8268973498322118625
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5505,31 +4753,176 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1058978345447164408}
+  - component: {fileID: 7984038255482101359}
+  - component: {fileID: 236086574692299803}
   m_Layer: 0
-  m_Name: spine_02
+  m_Name: Human.003_export_copy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1058978345447164408
+--- !u!4 &7984038255482101359
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8512674664781212589}
+  m_GameObject: {fileID: 8268973498322118625}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.10110922, y: 0, z: -0, w: 0.9948753}
-  m_LocalPosition: {x: -0, y: 0.0006650198, z: 1.0633812e-10}
-  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8229891078867211912}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &236086574692299803
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8268973498322118625}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 4a4518ead8aaa2b48b306b2a13f14197, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -8552327251687966643, guid: 202215a518327c145ad063e646529afb, type: 3}
+  m_Bones:
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8219266566289854322}
+  m_AABB:
+    m_Center: {x: 0.0000064154156, y: -0.00035970693, z: 0.008678621}
+    m_Extent: {x: 0.0049420344, y: 0.0026115244, z: 0.007288148}
+  m_DirtyAABB: 0
+--- !u!1 &8562408076227563711
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7581396695307459383}
+  m_Layer: 0
+  m_Name: middle_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7581396695307459383
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8562408076227563711}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0486796, y: -0.0050305324, z: -0.035270266, w: 0.99817884}
+  m_LocalPosition: {x: -0, y: 0.00030750938, z: 2.9802322e-10}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5844555597785276875}
-  m_Father: {fileID: 3794871522770794472}
+  - {fileID: 2593040849568736513}
+  m_Father: {fileID: 4892857268816581554}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8599068729455655754
+--- !u!1 &8568515938816153864
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5537,31 +4930,256 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2197915236501710594}
+  - component: {fileID: 8944438468328343222}
   m_Layer: 0
-  m_Name: pinky_03_r
+  m_Name: thumb_03_r_end
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2197915236501710594
+--- !u!4 &8944438468328343222
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8599068729455655754}
+  m_GameObject: {fileID: 8568515938816153864}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.011243035, y: 0.0031115646, z: -0.013404051, w: 0.9998421}
-  m_LocalPosition: {x: -0, y: 0.00014155026, z: 3.7252902e-11}
-  m_LocalScale: {x: 1, y: 1, z: 0.99999994}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0002571491, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5539494183430966140}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8655881459735540410
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2190403813663174371}
+  - component: {fileID: 5361074074923454307}
+  - component: {fileID: 4291814075300977997}
+  m_Layer: 0
+  m_Name: RightHandSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2190403813663174371
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655881459735540410}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.04324497, y: -0.056759395, z: -0.70398045, w: 0.7066256}
+  m_LocalPosition: {x: 0.44, y: 0.916, z: 0.193}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410635904188027050}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5361074074923454307
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655881459735540410}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 0
+--- !u!114 &4291814075300977997
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655881459735540410}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 2190403813663174371}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 4309342630357203679}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &8751284174847278957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8086587267984074501}
+  - component: {fileID: 9082148327661269747}
+  - component: {fileID: 6415819279099944591}
+  m_Layer: 0
+  m_Name: LeftBackSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8086587267984074501
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8751284174847278957}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.72605973, y: 0.000000014901156, z: -0, w: 0.68763167}
+  m_LocalPosition: {x: -0.059, y: 1.282, z: -0.146}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410635904188027050}
+  m_LocalEulerAnglesHint: {x: 93.11401, y: 0, z: 0}
+--- !u!114 &9082148327661269747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8751284174847278957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 7
+--- !u!114 &6415819279099944591
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8751284174847278957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 8086587267984074501}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 7458708668511229004}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &8765866046493892533
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5927012588123972360}
+  m_Layer: 0
+  m_Name: clavicle_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5927012588123972360
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8765866046493892533}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.013533592, y: -0.0062335213, z: -0.7455621, w: 0.6662696}
+  m_LocalPosition: {x: 0.0002277269, y: 0.002273369, z: 0.00009345285}
+  m_LocalScale: {x: 0.9999998, y: 0.9999999, z: 0.99999994}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 921667459844226887}
-  m_Father: {fileID: 3964992522341908183}
+  - {fileID: 8042139431053797484}
+  m_Father: {fileID: 4627148517924441137}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8611773341655986281
+--- !u!1 &8765867562633522863
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5569,89 +5187,573 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7007933616048893112}
+  - component: {fileID: 8477797510293541801}
+  - component: {fileID: 6604468563185287783}
+  - component: {fileID: 4823491710847929931}
   m_Layer: 0
-  m_Name: thigh_r
+  m_Name: Left Leg IK
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7007933616048893112
+--- !u!4 &8477797510293541801
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8611773341655986281}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.9475263, y: 0.10418324, z: -0.20727295, w: -0.21994945}
-  m_LocalPosition: {x: 0.0009458223, y: -0.00006587047, z: -0.00011003237}
-  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000011}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 892847256484991937}
-  m_Father: {fileID: 4519945923185583371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &9040096450213746847
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 476706900746659774}
-  - component: {fileID: 6028836889460103103}
-  m_Layer: 0
-  m_Name: MeshSockets
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &476706900746659774
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9040096450213746847}
+  m_GameObject: {fileID: 8765867562633522863}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5390393892021376998}
-  - {fileID: 115146769632896785}
-  - {fileID: 4108920179095155388}
-  - {fileID: 7440119764428091295}
-  - {fileID: 5383041750695327858}
-  - {fileID: 7786586981119059343}
-  - {fileID: 1118308365334064511}
-  - {fileID: 6793700598593668609}
-  - {fileID: 7212444211669496278}
-  - {fileID: 3170788153934991080}
-  - {fileID: 7103534773830694635}
-  - {fileID: 49697105603378068}
-  m_Father: {fileID: 1771497804972488078}
+  - {fileID: 4478234207697121360}
+  - {fileID: 4888662384396461074}
+  m_Father: {fileID: 5389314231816542757}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6028836889460103103
+--- !u!114 &6604468563185287783
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9040096450213746847}
+  m_GameObject: {fileID: 8765867562633522863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Effectors:
+  - m_Transform: {fileID: 4478234207697121360}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 4888662384396461074}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 0}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 4888662384396461074}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 4478234207697121360}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 4888662384396461074}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!114 &4823491710847929931
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8765867562633522863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_Root: {fileID: 9152289806704543833}
+    m_Mid: {fileID: 3602104167289862017}
+    m_Tip: {fileID: 8976758466170131055}
+    m_Target: {fileID: 4478234207697121360}
+    m_Hint: {fileID: 4888662384396461074}
+    m_TargetPositionWeight: 1
+    m_TargetRotationWeight: 1
+    m_HintWeight: 0
+    m_MaintainTargetPositionOffset: 1
+    m_MaintainTargetRotationOffset: 1
+--- !u!1 &8794792517938167433
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2473642875254494553}
+  m_Layer: 0
+  m_Name: ball_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2473642875254494553
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8794792517938167433}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.24330804, y: -0.39314923, z: 0.07650533, w: 0.8833922}
+  m_LocalPosition: {x: 3.958121e-11, y: 0.0012276003, z: -5.5879353e-11}
+  m_LocalScale: {x: 0.99999994, y: 1, z: 0.99999994}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4552200095070429695}
+  m_Father: {fileID: 8976758466170131055}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8899911758687519867
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5921673061741191239}
+  m_Layer: 0
+  m_Name: ring_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5921673061741191239
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8899911758687519867}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.050464388, y: 0.014995406, z: -0.021539208, w: 0.99838096}
+  m_LocalPosition: {x: 1.4901161e-10, y: 0.00022469096, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1.0000001}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2920973400686734298}
+  m_Father: {fileID: 4326347100290123948}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8946796392945560560
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7489914242463965228}
+  m_Layer: 0
+  m_Name: calf_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7489914242463965228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8946796392945560560}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.06561347, y: 0.22422159, z: -0.0023185785, w: 0.97232413}
+  m_LocalPosition: {x: -9.313225e-11, y: 0.0037228311, z: 0}
+  m_LocalScale: {x: 1, y: 1.0000001, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5643122131416389896}
+  m_Father: {fileID: 9046239492538980212}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8969041726243018327
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3834660483892733827}
+  - component: {fileID: 1666167377682639740}
+  m_Layer: 0
+  m_Name: Human.tongue01.003_export_copy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3834660483892733827
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8969041726243018327}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8229891078867211912}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &1666167377682639740
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8969041726243018327}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 4b3a05424ed17904c9abf7db18c7470d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4543397512444452662, guid: 202215a518327c145ad063e646529afb, type: 3}
+  m_Bones:
+  - {fileID: 8219266566289854322}
+  - {fileID: 342574450868786768}
+  - {fileID: 2851911031149534541}
+  - {fileID: 7458708668511229004}
+  - {fileID: 4627148517924441137}
+  - {fileID: 1912470366042116046}
+  - {fileID: 8689966920897482429}
+  - {fileID: 4006974465236572899}
+  - {fileID: 3410024656194104272}
+  - {fileID: 3505938461272075995}
+  - {fileID: 56571250049399604}
+  - {fileID: 1616949082261745534}
+  - {fileID: 4892857268816581554}
+  - {fileID: 7581396695307459383}
+  - {fileID: 2593040849568736513}
+  - {fileID: 6259473263663574704}
+  - {fileID: 4655419516182394031}
+  - {fileID: 1300560289145079763}
+  - {fileID: 5967336496010943389}
+  - {fileID: 4936391776413713684}
+  - {fileID: 3619657815403715820}
+  - {fileID: 8011564336138805084}
+  - {fileID: 1714339159582045435}
+  - {fileID: 2072760468485773797}
+  - {fileID: 5927012588123972360}
+  - {fileID: 8042139431053797484}
+  - {fileID: 1069430019985569169}
+  - {fileID: 4309342630357203679}
+  - {fileID: 2994304473762515553}
+  - {fileID: 656202537569593019}
+  - {fileID: 4335524568324716511}
+  - {fileID: 864817994278133829}
+  - {fileID: 4570561004290500836}
+  - {fileID: 4580032715661766560}
+  - {fileID: 4716333710905206286}
+  - {fileID: 6290355736433417671}
+  - {fileID: 220716193089346549}
+  - {fileID: 1151282446492632663}
+  - {fileID: 4326347100290123948}
+  - {fileID: 5921673061741191239}
+  - {fileID: 5615530770860326887}
+  - {fileID: 6073868566241321646}
+  - {fileID: 5539494183430966140}
+  - {fileID: 738403958125762811}
+  - {fileID: 7382531197968042743}
+  - {fileID: 9152289806704543833}
+  - {fileID: 3602104167289862017}
+  - {fileID: 8976758466170131055}
+  - {fileID: 2473642875254494553}
+  - {fileID: 9046239492538980212}
+  - {fileID: 7489914242463965228}
+  - {fileID: 5643122131416389896}
+  - {fileID: 2159381546251063548}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8219266566289854322}
+  m_AABB:
+    m_Center: {x: 0, y: -0.0009008263, z: 0.0142400805}
+    m_Extent: {x: 0.00021371382, y: 0.00034232042, z: 0.00014314055}
+  m_DirtyAABB: 0
+--- !u!1 &9030550104444846026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5250072804538552404}
+  - component: {fileID: 2730973569849820647}
+  - component: {fileID: 4115975104532980171}
+  m_Layer: 0
+  m_Name: HipsBackLeftSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5250072804538552404
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9030550104444846026}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.07002893, y: 0.000000029802322, z: -0.0000000055879354, w: 0.997545}
+  m_LocalPosition: {x: -0.122, y: 1.03, z: -0.059}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 410635904188027050}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2730973569849820647
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9030550104444846026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95b872d6d8715e746b23014fd2b11372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <SocketId>k__BackingField: 10
+--- !u!114 &4115975104532980171
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9030550104444846026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8935e03361a14ec4b8edc872f76bc822, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Data:
+    m_ConstrainedObject: {fileID: 5250072804538552404}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 342574450868786768}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_ConstrainedPositionAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_ConstrainedRotationAxes:
+      x: 1
+      y: 1
+      z: 1
+    m_MaintainPositionOffset: 1
+    m_MaintainRotationOffset: 1
+--- !u!1 &9120914510847068424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 911552020231453420}
+  m_Layer: 0
+  m_Name: LH IK Hint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &911552020231453420
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9120914510847068424}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.050784223, y: 0.06303089, z: 0.7134469, w: 0.6960184}
+  m_LocalPosition: {x: -0.295, y: 1.108, z: -0.192}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7848258744241299121}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9211738714411157052
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5389314231816542757}
+  - component: {fileID: 4044660433949996322}
+  m_Layer: 0
+  m_Name: CharacterRig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5389314231816542757
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9211738714411157052}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7280777454404120227}
+  - {fileID: 7848258744241299121}
+  - {fileID: 8477797510293541801}
+  - {fileID: 5249136800038137958}
+  - {fileID: 311986235194651136}
+  - {fileID: 7843781460543995551}
+  m_Father: {fileID: 5568684898111774494}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4044660433949996322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9211738714411157052}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Weight: 1
-  m_Effectors: []
---- !u!1001 &6734025049658258176
+  m_Effectors:
+  - m_Transform: {fileID: 7359459400941931864}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 4453659736414612958}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 0, g: 0.031424046, b: 1, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 911552020231453420}
+    m_Style:
+      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
+      color: {r: 0, g: 0.045587063, b: 1, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 11472554110216234}
+    m_Style:
+      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!1001 &8483879172441387363
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -5665,15 +5767,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.56
+      value: 0.97625273
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.0000001519171
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.5576482
+      value: 3.841366
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       propertyPath: m_LocalRotation.w
@@ -5736,7 +5838,7 @@ PrefabInstance:
       value: AgentBasedOnhuman003
       objectReference: {fileID: 0}
     - target: {fileID: 2021133116110439406, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
-      propertyPath: m_Materials.Array.data[0]
+      propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: fb4b7816a049cf244af9684f69d89b92, type: 2}
     - target: {fileID: 5866666021909216657, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
@@ -5814,90 +5916,95 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1771497804972488078}
+      addedObject: {fileID: 5568684898111774494}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 4219102615782077759}
+      addedObject: {fileID: 6529172150956068362}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7529814817853636081}
+      addedObject: {fileID: 7984038255482101359}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 5108216991000040777}
+      addedObject: {fileID: 8156958266633294146}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1075986095039001427}
+      addedObject: {fileID: 1823408102826035574}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1426295172490650552}
+      addedObject: {fileID: 5060729341632676252}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 6596221832464820943}
+      addedObject: {fileID: 6239330415846787786}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1852076776830461685}
+      addedObject: {fileID: 8063266617321443551}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 85292284420255197}
+      addedObject: {fileID: 6657928999061843591}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 6403676991521092808}
+      addedObject: {fileID: 8580869714061137923}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 3371423488310119115}
+      addedObject: {fileID: 1413476190920327439}
     - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 3776138140182054562}
+      addedObject: {fileID: 3834660483892733827}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 2945422932974597233}
+      addedObject: {fileID: 8939769552589757569}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 3109694859159132069}
+      addedObject: {fileID: 6120128983621741242}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 663297428447883988}
+      addedObject: {fileID: 9169060095770690529}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 2807192187105667567}
+      addedObject: {fileID: 6943269213944613211}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7331076225757085389}
+      addedObject: {fileID: 2519761764946764365}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 6829230450403550927}
+      addedObject: {fileID: 3258158512388423883}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 7031094660139619390}
+      addedObject: {fileID: 997264867528979936}
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 2560639622147887435}
+      addedObject: {fileID: 1712942855541934040}
   m_SourcePrefab: {fileID: 100100000, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
---- !u!1 &5887746002076257873 stripped
+--- !u!4 &8229891078867211912 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
+  m_PrefabInstance: {fileID: 8483879172441387363}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8754332443201834034 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
-  m_PrefabInstance: {fileID: 6734025049658258176}
+  m_PrefabInstance: {fileID: 8483879172441387363}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2945422932974597233
+--- !u!114 &8939769552589757569
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5887746002076257873}
+  m_GameObject: {fileID: 8754332443201834034}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2eb11c02fcaa7fa40861161120bf3b98, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &3109694859159132069
+--- !u!114 &6120128983621741242
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5887746002076257873}
+  m_GameObject: {fileID: 8754332443201834034}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8d1f53ec0650eb049b6fa464e3c03437, type: 3}
@@ -5907,13 +6014,13 @@ MonoBehaviour:
   angularSpeed: Turn
   rotationDirection: RotationDirection
   isRotating: IsRotating
---- !u!195 &663297428447883988
+--- !u!195 &9169060095770690529
 NavMeshAgent:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5887746002076257873}
+  m_GameObject: {fileID: 8754332443201834034}
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.33
@@ -5929,45 +6036,49 @@ NavMeshAgent:
   m_BaseOffset: -0.06
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
---- !u!114 &2807192187105667567
+--- !u!114 &6943269213944613211
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5887746002076257873}
+  m_GameObject: {fileID: 8754332443201834034}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 96bc75292d584fe4598ab674a7c7ddfd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <TwoBoneIKConstraintRightArm>k__BackingField: {fileID: 2691302938270690217}
-  <TwoBoneIKConstraintLeftArm>k__BackingField: {fileID: 6693723757930246060}
---- !u!114 &7331076225757085389
+  <TwoBoneIKConstraintRightArm>k__BackingField: {fileID: 8811367747448979784}
+  <TwoBoneIKConstraintLeftArm>k__BackingField: {fileID: 8076137481123668602}
+  <MultiParentConstraintHip>k__BackingField: {fileID: 7382914244123314891}
+  <TwoBoneIKConstraintLeftLeg>k__BackingField: {fileID: 4823491710847929931}
+  <TwoBoneIKConstraintRightLeg>k__BackingField: {fileID: 7423238105630776296}
+  <MultiAimConstraintSpine>k__BackingField: {fileID: 7745958410504067028}
+--- !u!114 &2519761764946764365
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5887746002076257873}
+  m_GameObject: {fileID: 8754332443201834034}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fff0960ef4ea6e04eac66b4a7fd2189d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_RigLayers:
-  - m_Rig: {fileID: 6028836889460103103}
+  - m_Rig: {fileID: 8753248105300176801}
     m_Active: 1
-  - m_Rig: {fileID: 7531143227365579660}
+  - m_Rig: {fileID: 4044660433949996322}
     m_Active: 1
   m_Effectors: []
---- !u!114 &6829230450403550927
+--- !u!114 &3258158512388423883
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5887746002076257873}
+  m_GameObject: {fileID: 8754332443201834034}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 88c1ed013dd3e92439b19c5c699179c6, type: 3}
@@ -5990,29 +6101,30 @@ MonoBehaviour:
   occlusionLayers:
     serializedVersion: 2
     m_Bits: 1
---- !u!114 &7031094660139619390
+--- !u!114 &997264867528979936
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5887746002076257873}
+  m_GameObject: {fileID: 8754332443201834034}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: afa2f315da5127e47a996e328f4ffff3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!82 &2560639622147887435
+--- !u!82 &1712942855541934040
 AudioSource:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5887746002076257873}
+  m_GameObject: {fileID: 8754332443201834034}
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
@@ -6098,8 +6210,3 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!4 &6556864370830939371 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 26f8cd740528f3b469c4f32fe28b8306, type: 3}
-  m_PrefabInstance: {fileID: 6734025049658258176}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Virtual Agents Framework/Samples/MultipleAgentsSample/Multiple Agents Sample.unity
+++ b/Assets/Virtual Agents Framework/Samples/MultipleAgentsSample/Multiple Agents Sample.unity
@@ -358,6 +358,17 @@ MonoBehaviour:
   m_ShadowLayerMask: 1
   m_RenderingLayers: 1
   m_ShadowRenderingLayers: 1
+--- !u!114 &700251886 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8939769552589757569, guid: 0907f1986a2d090408230cb332151cc2, type: 3}
+  m_PrefabInstance: {fileID: 2797381020595101611}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2eb11c02fcaa7fa40861161120bf3b98, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &959590311
 GameObject:
   m_ObjectHideFlags: 0
@@ -422,6 +433,17 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1019947944 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4405029950365877461, guid: 1da479809886bf844969b0b608853771, type: 3}
+  m_PrefabInstance: {fileID: 2179171255588229255}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2eb11c02fcaa7fa40861161120bf3b98, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1083162461
 GameObject:
   m_ObjectHideFlags: 0
@@ -447,7 +469,7 @@ Transform:
   m_GameObject: {fileID: 1083162461}
   serializedVersion: 2
   m_LocalRotation: {x: -4.656613e-10, y: -1.1641532e-10, z: -0.0000000037252903, w: 1}
-  m_LocalPosition: {x: -3, y: 0, z: 7}
+  m_LocalPosition: {x: -2.52, y: -0, z: 7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -685,11 +707,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c29fed159bf147946b9dcc6ab674abcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  agent: {fileID: 718444494786536328}
+  agent: {fileID: 1019947944}
   waypoints:
   - {fileID: 1671340876}
   - {fileID: 1083162462}
-  agentTwo: {fileID: 718444494139462993}
+  agentTwo: {fileID: 700251886}
 --- !u!1 &1671340875
 GameObject:
   m_ObjectHideFlags: 0
@@ -715,7 +737,7 @@ Transform:
   m_GameObject: {fileID: 1671340875}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0.0000000018626451, w: 1}
-  m_LocalPosition: {x: -5, y: 0, z: 7}
+  m_LocalPosition: {x: -5, y: 0.106, z: 7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -726,28 +748,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 212402951927973884, guid: 2962848ab48f0e4459691ff3d6d1eed0, type: 3}
   m_PrefabInstance: {fileID: 1023428232005854918}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &718444494139462993 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3000973314931460519, guid: 1da479809886bf844969b0b608853771, type: 3}
-  m_PrefabInstance: {fileID: 2179171255588229255}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2eb11c02fcaa7fa40861161120bf3b98, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &718444494786536328 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2945422932974597233, guid: 0907f1986a2d090408230cb332151cc2, type: 3}
-  m_PrefabInstance: {fileID: 2797381020595101611}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2eb11c02fcaa7fa40861161120bf3b98, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1023428232005854918
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -840,6 +840,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2989011612062175184, guid: 1da479809886bf844969b0b608853771, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 2989011612062175184, guid: 1da479809886bf844969b0b608853771, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.83
+      objectReference: {fileID: 0}
     - target: {fileID: 4749814036626849447, guid: 1da479809886bf844969b0b608853771, type: 3}
       propertyPath: m_LocalPosition.x
       value: -4.6508493
@@ -940,6 +948,14 @@ PrefabInstance:
     - target: {fileID: 6556864370830939371, guid: 0907f1986a2d090408230cb332151cc2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229891078867211912, guid: 0907f1986a2d090408230cb332151cc2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229891078867211912, guid: 0907f1986a2d090408230cb332151cc2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.84
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
The newly introduced prefabs of the realistic character models were imported with an older version of the import function, making them unusable with sitting tasks and difficult to use with item tasks.

This pull request reimports the 3D models with the new import function, manually tweaks the item sockets to fit the new models a bit better and replaces the old prefabs.

(Note: If needed, anyone can replicate this fix manually by applying the current import function to the 3D models located in Assets/Virtual Agents Framework/Runtime/3D Models.)